### PR TITLE
Use existing environment variable

### DIFF
--- a/config/reverb.php
+++ b/config/reverb.php
@@ -31,7 +31,7 @@ return [
         'reverb' => [
             'host' => env('REVERB_SERVER_HOST', '0.0.0.0'),
             'port' => env('REVERB_SERVER_PORT', 8080),
-            'hostname' => env('REVERB_SERVER_HOSTNAME'),
+            'hostname' => env('REVERB_HOST'),
             'options' => [
                 'tls' => [],
             ],

--- a/src/Servers/Reverb/Console/Commands/StartServer.php
+++ b/src/Servers/Reverb/Console/Commands/StartServer.php
@@ -65,7 +65,7 @@ class StartServer extends Command implements SignalableCommandInterface
         $this->ensureRestartCommandIsRespected($server, $loop, $host, $port);
         $this->ensurePulseEventsAreCollected($loop, $config['pulse_ingest_interval']);
 
-        $this->components->info('Starting '.($server->isSecure() ? 'secure ' : '')."server on {$host}:{$port}".($hostname ? " ({$hostname})" : ''));
+        $this->components->info('Starting '.($server->isSecure() ? 'secure ' : '')."server on {$host}:{$port}".(($hostname && $hostname !== $host) ? " ({$hostname})" : ''));
 
         $server->start();
     }


### PR DESCRIPTION
I thought about this after our discussion around https://github.com/laravel/reverb/pull/46

We already have the `REVERB_HOST` environment variable used to instruct Pusher and Echo how to connect to the Reverb server. This will already need to be updated when using a Herd or Valet certificate so makes sense reuse this and avoid an additional env var.