### PR TITLE
Handles invalid requests

### DIFF
--- a/src/Servers/Reverb/Http/Server.php
+++ b/src/Servers/Reverb/Http/Server.php
@@ -70,6 +70,8 @@ class Server
             $request = Request::from($message, $connection);
         } catch (OverflowException $e) {
             $this->close($connection, 413, 'Payload too large.');
+        } catch (Throwable $e) {
+            $this->close($connection, 400, 'Bad request.');
         }
 
         return $request ?? null;


### PR DESCRIPTION
Whilst testing, I noticed the following request with unexpected `start-line` caused an exception and killed the server.

This PR adresses that issue by catching the error an closing the request with `400 Bad Request`

<img width="591" alt="Screenshot 2024-03-07 at 16 50 27" src="https://github.com/laravel/reverb/assets/3438564/6d8f2621-82fc-4775-a85a-513d5f2c32df">

<img width="820" alt="Screenshot 2024-03-07 at 19 21 47" src="https://github.com/laravel/reverb/assets/3438564/53aa4451-386b-4f6e-b2a5-687cc2b7db55">
