### PR TITLE
[1.x] Fixes install command for applications migrated from 10.x to 11.x

### DIFF
--- a/src/Console/Commands/InstallCommand.php
+++ b/src/Console/Commands/InstallCommand.php
@@ -132,6 +132,8 @@ class InstallCommand extends Command
      */
     protected function enableBroadcasting(): void
     {
+        $this->enableBroadcastServiceProvider();
+
         if (File::exists(base_path('routes/channels.php'))) {
             return;
         }
@@ -142,9 +144,9 @@ class InstallCommand extends Command
             return;
         }
 
-        $this->enableBroadcastServiceProvider();
-
-        $this->callSilently('install:broadcasting');
+        if ($this->getApplication()->has('install:broadcasting')) {
+            $this->call('install:broadcasting', ['--no-interaction' => true]);
+        }
     }
 
     /**

--- a/src/Console/Commands/InstallCommand.php
+++ b/src/Console/Commands/InstallCommand.php
@@ -97,10 +97,6 @@ class InstallCommand extends Command
      */
     protected function updateBroadcastingConfiguration(): void
     {
-        if (! $this->isLaravelTen()) {
-            return;
-        }
-
         if ($this->laravel->config->has('broadcasting.connections.reverb')) {
             return;
         }
@@ -146,11 +142,7 @@ class InstallCommand extends Command
             return;
         }
 
-        if ($this->isLaravelTen()) {
-            $this->enableBroadcastServiceProvider();
-
-            return;
-        }
+        $this->enableBroadcastServiceProvider();
 
         $this->callSilently('install:broadcasting');
     }
@@ -188,13 +180,5 @@ class InstallCommand extends Command
                 return $matches[1].'=reverb';
             })
         );
-    }
-
-    /**
-     * Determine if the application is using Laravel 10.
-     */
-    protected function isLaravelTen(): bool
-    {
-        return version_compare($this->laravel->version(), '11.0', '<');
     }
 }


### PR DESCRIPTION
This PR updates the install process to:

- Always attempt to enable the `BroadcastServiceProvider` in `app.php`
- Always attempt to add Reverb's configuration options to `broadcasting.php`.

Resolves #79 
