### PR TITLE
[1.x] Prevents exception when no auth token passed

### DIFF
--- a/src/Protocols/Pusher/Channels/Concerns/InteractsWithPrivateChannels.php
+++ b/src/Protocols/Pusher/Channels/Concerns/InteractsWithPrivateChannels.php
@@ -21,7 +21,7 @@ trait InteractsWithPrivateChannels
     /**
      * Deteremine whether the given authentication token is valid.
      */
-    protected function verify(Connection $connection, string $auth, ?string $data = null): bool
+    protected function verify(Connection $connection, ?string $auth = null, ?string $data = null): bool
     {
         $signature = "{$connection->id()}:{$this->name()}";
 

--- a/tests/Feature/Protocols/Pusher/Reverb/ServerTest.php
+++ b/tests/Feature/Protocols/Pusher/Reverb/ServerTest.php
@@ -405,3 +405,27 @@ it('removes a channel when no subscribers remain', function () {
 
     expect(channels()->all())->toHaveCount(0);
 });
+
+it('fails to subscribe to private channel with no auth token', function () {
+    $response = send([
+        'event' => 'pusher:subscribe',
+        'data' => [
+            'channel' => 'private-test-channel',
+            'auth' => null,
+        ],
+    ], connect());
+
+    expect($response)->toBe('{"event":"pusher:error","data":"{\"code\":4009,\"message\":\"Connection is unauthorized\"}"}');
+});
+
+it('fails to subscribe to presence channel with no auth token', function () {
+    $response = send([
+        'event' => 'pusher:subscribe',
+        'data' => [
+            'channel' => 'presence-test-channel',
+            'auth' => null,
+        ],
+    ], connect());
+
+    expect($response)->toBe('{"event":"pusher:error","data":"{\"code\":4009,\"message\":\"Connection is unauthorized\"}"}');
+});

--- a/tests/Unit/Protocols/Pusher/Channels/PrivateChannelTest.php
+++ b/tests/Unit/Protocols/Pusher/Channels/PrivateChannelTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Laravel\Reverb\Protocols\Pusher\Channels\PresenceChannel;
 use Laravel\Reverb\Protocols\Pusher\Channels\PrivateChannel;
 use Laravel\Reverb\Protocols\Pusher\Contracts\ChannelConnectionManager;
 use Laravel\Reverb\Protocols\Pusher\Exceptions\ConnectionUnauthorized;
@@ -53,4 +54,16 @@ it('fails to subscribe if the signature is invalid', function () {
     $this->channelConnectionManager->shouldNotReceive('subscribe');
 
     $channel->subscribe($this->connection, 'invalid-signature');
+})->throws(ConnectionUnauthorized::class);
+
+it('fails to subscribe to a private channel with no auth token', function () {
+    $channel = new PrivateChannel('private-test-channel');
+
+    $channel->subscribe($this->connection, null);
+})->throws(ConnectionUnauthorized::class);
+
+it('fails to subscribe to a presence channel with no auth token', function () {
+    $channel = new PresenceChannel('presence-test-channel');
+
+    $channel->subscribe($this->connection, null);
 })->throws(ConnectionUnauthorized::class);


### PR DESCRIPTION
Resolves #89 

Updated the `verify` method for private channels to accept a nullable auth token. Doing so means the `ConnectionUnauthorized` exception will be thrown and the correct error message sent across the WebSocket rather than throwing a `TypeError` and stopping the server.