### PR TITLE
Fix invalid response data of event pusher_internal:subscription_succeeded

### DIFF
--- a/src/Protocols/Pusher/Channels/Concerns/InteractsWithPresenceChannels.php
+++ b/src/Protocols/Pusher/Channels/Concerns/InteractsWithPresenceChannels.php
@@ -73,7 +73,7 @@ trait InteractsWithPresenceChannels
         return [
             'presence' => [
                 'count' => $connections->count() ?? 0,
-                'ids' => $connections->map(fn ($connection) => $connection['user_id'])->all(),
+                'ids' => $connections->map(fn ($connection) => $connection['user_id'])->values()->all(),
                 'hash' => $connections->keyBy('user_id')->map->user_info->toArray(),
             ],
         ];


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
## Issue
- https://github.com/laravel/reverb/issues/92

## Overview
Using `collection->values()->all()` instead of `collection->all()` to reset the array key.

## Screenshot
|Before|After|
|-|-|
|![](https://github.com/laravel/reverb/assets/11713395/e4513de1-08c0-456c-b148-5b3d8a42eb9b)|![](https://github.com/laravel/reverb/assets/11713395/64030ece-8d23-4930-af48-38f3fb0e8f4c)|



