### PR TITLE
[1.x] Sends data property when empty

### DIFF
--- a/src/Protocols/Pusher/EventHandler.php
+++ b/src/Protocols/Pusher/EventHandler.php
@@ -145,12 +145,12 @@ class EventHandler
     /**
      * Format the payload for the given event.
      */
-    public function formatPayload(string $event, array $data = [], ?string $channel = null, string $prefix = 'pusher:'): string|false
+    public function formatPayload(string $event, array $data = [], ?string $channel = null): string|false
     {
         return json_encode(
             array_filter([
-                'event' => $prefix.$event,
-                'data' => empty($data) ? '{}' : json_encode($data),
+                'event' => 'pusher:'.$event,
+                'data' => empty($data) ? null : json_encode($data),
                 'channel' => $channel,
             ])
         );
@@ -161,6 +161,12 @@ class EventHandler
      */
     public function formatInternalPayload(string $event, array $data = [], $channel = null): string|false
     {
-        return static::formatPayload($event, $data, $channel, 'pusher_internal:');
+        return json_encode(
+            array_filter([
+                'event' => 'pusher_internal:'.$event,
+                'data' => empty($data) ? '{}' : json_encode($data),
+                'channel' => $channel,
+            ])
+        );
     }
 }

--- a/src/Protocols/Pusher/EventHandler.php
+++ b/src/Protocols/Pusher/EventHandler.php
@@ -145,11 +145,11 @@ class EventHandler
     /**
      * Format the payload for the given event.
      */
-    public function formatPayload(string $event, array $data = [], ?string $channel = null): string|false
+    public function formatPayload(string $event, array $data = [], ?string $channel = null, string $prefix = 'pusher:'): string|false
     {
         return json_encode(
             array_filter([
-                'event' => 'pusher:'.$event,
+                'event' => $prefix.$event,
                 'data' => empty($data) ? null : json_encode($data),
                 'channel' => $channel,
             ])
@@ -164,7 +164,7 @@ class EventHandler
         return json_encode(
             array_filter([
                 'event' => 'pusher_internal:'.$event,
-                'data' => empty($data) ? '{}' : json_encode($data),
+                'data' => json_encode((object) $data),
                 'channel' => $channel,
             ])
         );

--- a/src/Protocols/Pusher/EventHandler.php
+++ b/src/Protocols/Pusher/EventHandler.php
@@ -150,7 +150,7 @@ class EventHandler
         return json_encode(
             array_filter([
                 'event' => $prefix.$event,
-                'data' => empty($data) ? null : json_encode($data),
+                'data' => empty($data) ? '{}' : json_encode($data),
                 'channel' => $channel,
             ])
         );

--- a/tests/Feature/Protocols/Pusher/Reverb/ServerTest.php
+++ b/tests/Feature/Protocols/Pusher/Reverb/ServerTest.php
@@ -21,13 +21,13 @@ it('can subscribe to a channel', function () {
     $response = subscribe('test-channel');
 
     expect(channels()->find('test-channel')->connections())->toHaveCount(1);
-    expect($response)->toBe('{"event":"pusher_internal:subscription_succeeded","channel":"test-channel"}');
+    expect($response)->toBe('{"event":"pusher_internal:subscription_succeeded","data":"{}","channel":"test-channel"}');
 });
 
 it('can subscribe to a private channel', function () {
     $response = subscribe('private-test-channel');
 
-    expect($response)->toBe('{"event":"pusher_internal:subscription_succeeded","channel":"private-test-channel"}');
+    expect($response)->toBe('{"event":"pusher_internal:subscription_succeeded","data":"{}","channel":"private-test-channel"}');
 });
 
 it('can subscribe to a presence channel', function () {
@@ -41,13 +41,13 @@ it('can subscribe to a presence channel', function () {
 it('can subscribe to a cache channel', function () {
     $response = subscribe('cache-test-channel');
 
-    expect($response)->toBe('{"event":"pusher_internal:subscription_succeeded","channel":"cache-test-channel"}');
+    expect($response)->toBe('{"event":"pusher_internal:subscription_succeeded","data":"{}","channel":"cache-test-channel"}');
 });
 
 it('can subscribe to a private cache channel', function () {
     $response = subscribe('private-cache-test-channel');
 
-    expect($response)->toBe('{"event":"pusher_internal:subscription_succeeded","channel":"private-cache-test-channel"}');
+    expect($response)->toBe('{"event":"pusher_internal:subscription_succeeded","data":"{}","channel":"private-cache-test-channel"}');
 });
 
 it('can subscribe to a presence cache channel', function () {
@@ -141,21 +141,21 @@ it('can receive a cached message when joining a presence cache channel', functio
     $connection->assertReceived('{"event":"App\\\\Events\\\\TestEvent","data":"{\"foo\":\"bar\"}","channel":"presence-cache-test-channel"}');
 });
 
-it('can receive a cach missed message when joining a cache channel with an empty cache', function () {
+it('can receive a cache missed message when joining a cache channel with an empty cache', function () {
     $connection = connect();
     subscribe('cache-test-channel', connection: $connection);
 
     $connection->assertReceived('{"event":"pusher:cache_miss","channel":"cache-test-channel"}');
 });
 
-it('can receive a cach missed message when joining a private cache channel with an empty cache', function () {
+it('can receive a cache missed message when joining a private cache channel with an empty cache', function () {
     $connection = connect();
     subscribe('private-cache-test-channel', connection: $connection);
 
     $connection->assertReceived('{"event":"pusher:cache_miss","channel":"private-cache-test-channel"}');
 });
 
-it('can receive a cach missed message when joining a presence cache channel with an empty cache', function () {
+it('can receive a cache missed message when joining a presence cache channel with an empty cache', function () {
     $connection = connect();
     subscribe('presence-cache-test-channel', connection: $connection);
 
@@ -455,7 +455,7 @@ it('allows message within the max allowed size', function () {
         ],
     ], $connection);
 
-    expect($response)->toBe('{"event":"pusher_internal:subscription_succeeded","channel":"my-channel"}');
+    expect($response)->toBe('{"event":"pusher_internal:subscription_succeeded","data":"{}","channel":"my-channel"}');
 });
 
 it('buffers large requests correctly', function () {

--- a/tests/Unit/Protocols/Pusher/EventTest.php
+++ b/tests/Unit/Protocols/Pusher/EventTest.php
@@ -64,11 +64,10 @@ it('can correctly format a payload', function () {
         'foo',
         ['bar' => 'baz'],
         'test-channel',
-        'reverb:'
     );
 
     expect($payload)->toBe(json_encode([
-        'event' => 'reverb:foo',
+        'event' => 'pusher:foo',
         'data' => json_encode(['bar' => 'baz']),
         'channel' => 'test-channel',
     ]));
@@ -85,7 +84,6 @@ it('can correctly format an internal payload', function () {
         'foo',
         ['bar' => 'baz'],
         'test-channel',
-        'reverb:'
     );
 
     expect($payload)->toBe(json_encode([
@@ -98,5 +96,6 @@ it('can correctly format an internal payload', function () {
 
     expect($payload)->toBe(json_encode([
         'event' => 'pusher_internal:foo',
+        'data' => '{}',
     ]));
 });

--- a/tests/Unit/Protocols/Pusher/EventTest.php
+++ b/tests/Unit/Protocols/Pusher/EventTest.php
@@ -33,6 +33,7 @@ it('can subscribe to a channel', function () {
 
     $this->connection->assertReceived([
         'event' => 'pusher_internal:subscription_succeeded',
+        'data' => '{}',
         'channel' => 'test-channel',
     ]);
 });

--- a/tests/Unit/Protocols/Pusher/ServerTest.php
+++ b/tests/Unit/Protocols/Pusher/ServerTest.php
@@ -56,6 +56,7 @@ it('can handle a new message', function () {
 
     $connection->assertReceived([
         'event' => 'pusher_internal:subscription_succeeded',
+        'data' => '{}',
         'channel' => 'test-channel',
     ]);
 });
@@ -108,6 +109,7 @@ it('can subscribe a user to a channel', function () {
 
     $connection->assertReceived([
         'event' => 'pusher_internal:subscription_succeeded',
+        'data' => '{}',
         'channel' => 'test-channel',
     ]);
 });
@@ -125,6 +127,7 @@ it('can subscribe a user to a private channel', function () {
 
     $connection->assertReceived([
         'event' => 'pusher_internal:subscription_succeeded',
+        'data' => '{}',
         'channel' => 'private-test-channel',
     ]);
 });
@@ -165,6 +168,7 @@ it('receives no data when no previous event triggered when joining a cache chann
 
     $connection->assertReceived([
         'event' => 'pusher_internal:subscription_succeeded',
+        'data' => '{}',
         'channel' => 'cache-test-channel',
     ]);
     $connection->assertReceived([
@@ -199,6 +203,7 @@ it('receives last triggered event when joining a cache channel', function () {
 
     $connection->assertReceived([
         'event' => 'pusher_internal:subscription_succeeded',
+        'data' => '{}',
         'channel' => 'cache-test-channel',
     ]);
     $connection->assertReceived(['foo' => 'bar']);


### PR DESCRIPTION
This PR fixes missing `data` property for `pusher_internal` events.

Fixes #123 