### PR TITLE
[1.x] Improves exception handling and logging

### DIFF
--- a/src/Loggers/CliLogger.php
+++ b/src/Loggers/CliLogger.php
@@ -4,6 +4,7 @@ namespace Laravel\Reverb\Loggers;
 
 use Illuminate\Console\OutputStyle;
 use Illuminate\Console\View\Components\Factory;
+use Illuminate\Support\Str;
 use Laravel\Reverb\Console\Components\Message;
 use Laravel\Reverb\Contracts\Logger;
 
@@ -58,7 +59,7 @@ class CliLogger implements Logger
         $message = json_encode($message, JSON_PRETTY_PRINT);
 
         (new Message($this->output))->render(
-            $message
+            Str::limit($message, 200)
         );
     }
 

--- a/src/Protocols/Pusher/Channels/Channel.php
+++ b/src/Protocols/Pusher/Channels/Channel.php
@@ -102,7 +102,7 @@ class Channel
 
         $message = json_encode($payload);
 
-        Log::info('Broadcasting to', $this->name());
+        Log::info('Broadcasting To', $this->name());
         Log::message($message);
 
         foreach ($this->connections() as $connection) {
@@ -121,7 +121,7 @@ class Channel
     {
         $message = json_encode($payload);
 
-        Log::info('Broadcasting to', $this->name());
+        Log::info('Broadcasting To', $this->name());
         Log::message($message);
 
         foreach ($this->connections() as $connection) {

--- a/src/Protocols/Pusher/Channels/Channel.php
+++ b/src/Protocols/Pusher/Channels/Channel.php
@@ -65,7 +65,7 @@ class Channel
      */
     public function subscribe(Connection $connection, ?string $auth = null, ?string $data = null): void
     {
-        $this->connections->add($connection, $data ? json_decode($data, true) : []);
+        $this->connections->add($connection, $data ? json_decode($data, associative: true, flags: JSON_THROW_ON_ERROR) : []);
     }
 
     /**

--- a/src/Protocols/Pusher/Channels/Channel.php
+++ b/src/Protocols/Pusher/Channels/Channel.php
@@ -3,6 +3,7 @@
 namespace Laravel\Reverb\Protocols\Pusher\Channels;
 
 use Laravel\Reverb\Contracts\Connection;
+use Laravel\Reverb\Loggers\Log;
 use Laravel\Reverb\Protocols\Pusher\Concerns\SerializesChannels;
 use Laravel\Reverb\Protocols\Pusher\Contracts\ChannelConnectionManager;
 use Laravel\Reverb\Protocols\Pusher\Contracts\ChannelManager;
@@ -101,6 +102,9 @@ class Channel
 
         $message = json_encode($payload);
 
+        Log::info('Broadcasting to', $this->name());
+        Log::message($message);
+
         foreach ($this->connections() as $connection) {
             if ($except->id() === $connection->id()) {
                 continue;
@@ -116,6 +120,9 @@ class Channel
     public function broadcastToAll(array $payload): void
     {
         $message = json_encode($payload);
+
+        Log::info('Broadcasting to', $this->name());
+        Log::message($message);
 
         foreach ($this->connections() as $connection) {
             $connection->send($message);

--- a/src/Protocols/Pusher/Channels/Concerns/InteractsWithPresenceChannels.php
+++ b/src/Protocols/Pusher/Channels/Concerns/InteractsWithPresenceChannels.php
@@ -20,7 +20,7 @@ trait InteractsWithPresenceChannels
         parent::broadcastInternally(
             [
                 'event' => 'pusher_internal:member_added',
-                'data' => $data ? json_decode($data, true) : [],
+                'data' => $data ? json_decode($data, associative: true, flags: JSON_THROW_ON_ERROR) : [],
                 'channel' => $this->name(),
             ],
             $connection

--- a/src/Protocols/Pusher/Http/Controllers/EventsBatchController.php
+++ b/src/Protocols/Pusher/Http/Controllers/EventsBatchController.php
@@ -26,7 +26,7 @@ class EventsBatchController extends Controller
     {
         $this->verify($request, $connection, $appId);
 
-        $payload = json_decode($this->body, true);
+        $payload = json_decode($this->body, associative: true, flags: JSON_THROW_ON_ERROR);
 
         $validator = $this->validator($payload);
 

--- a/src/Protocols/Pusher/Http/Controllers/EventsController.php
+++ b/src/Protocols/Pusher/Http/Controllers/EventsController.php
@@ -25,7 +25,7 @@ class EventsController extends Controller
     {
         $this->verify($request, $connection, $appId);
 
-        $payload = json_decode($this->body, true);
+        $payload = json_decode($this->body, associative: true, flags: JSON_THROW_ON_ERROR);
 
         $validator = $this->validator($payload);
 

--- a/src/Protocols/Pusher/PusherPubSubIncomingMessageHandler.php
+++ b/src/Protocols/Pusher/PusherPubSubIncomingMessageHandler.php
@@ -12,7 +12,7 @@ class PusherPubSubIncomingMessageHandler implements PubSubIncomingMessageHandler
      */
     public function handle(string $payload): void
     {
-        $event = json_decode($payload, true);
+        $event = json_decode($payload, associative: true, flags: JSON_THROW_ON_ERROR);
 
         $application = unserialize($event['application']);
 

--- a/src/Protocols/Pusher/Server.php
+++ b/src/Protocols/Pusher/Server.php
@@ -49,9 +49,9 @@ class Server
 
         $from->touch();
 
-        $event = json_decode($message, true);
-
         try {
+            $event = json_decode($message, associative: true, flags: JSON_THROW_ON_ERROR);
+
             match (Str::startsWith($event['event'], 'pusher:')) {
                 true => $this->handler->handle(
                     $from,

--- a/src/Servers/Reverb/Http/Server.php
+++ b/src/Servers/Reverb/Http/Server.php
@@ -3,6 +3,7 @@
 namespace Laravel\Reverb\Servers\Reverb\Http;
 
 use Illuminate\Support\Str;
+use Laravel\Reverb\Loggers\Log;
 use Laravel\Reverb\Servers\Reverb\Concerns\ClosesConnections;
 use OverflowException;
 use Psr\Http\Message\RequestInterface;
@@ -57,6 +58,7 @@ class Server
         try {
             $this->router->dispatch($request, $connection);
         } catch (Throwable $e) {
+            Log::error($e->getMessage());
             $this->close($connection, 500, 'Internal server error.');
         }
     }

--- a/src/Servers/Reverb/Publishing/RedisPubSubProvider.php
+++ b/src/Servers/Reverb/Publishing/RedisPubSubProvider.php
@@ -61,7 +61,7 @@ class RedisPubSubProvider implements PubSubProvider
     public function on(string $event, callable $callback): void
     {
         $this->subscribingClient->on('message', function (string $channel, string $payload) use ($event, $callback) {
-            $payload = json_decode($payload, true);
+            $payload = json_decode($payload, associative: true, flags: JSON_THROW_ON_ERROR);
 
             if (($payload['type'] ?? null) === $event) {
                 $callback($payload);

--- a/tests/Feature/Protocols/Pusher/Reverb/EventsBatchControllerTest.php
+++ b/tests/Feature/Protocols/Pusher/Reverb/EventsBatchControllerTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Laravel\Reverb\Tests\ReverbTestCase;
+use React\Http\Message\ResponseException;
 
 use function React\Async\await;
 
@@ -138,3 +139,9 @@ it('can receive an event batch trigger with multiple events and gather info for 
     expect($response->getStatusCode())->toBe(200);
     expect($response->getBody()->getContents())->toBe('{"batch":[{"user_count":1},{}]}');
 });
+
+it('fails when payload is invalid', function () {
+    $response = await($this->signedPostRequest('batch_events', null));
+
+    expect($response->getStatusCode())->toBe(500);
+})->throws(ResponseException::class, exceptionCode: 500);

--- a/tests/Feature/Protocols/Pusher/Reverb/EventsControllerTest.php
+++ b/tests/Feature/Protocols/Pusher/Reverb/EventsControllerTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Laravel\Reverb\Contracts\Logger;
 use Laravel\Reverb\Tests\ReverbTestCase;
 use React\Http\Message\ResponseException;
 
@@ -165,3 +166,9 @@ it('can trigger an event within the max message size', function () {
     expect($response->getStatusCode())->toBe(200);
     expect($response->getBody()->getContents())->toBe('{}');
 });
+
+it('fails when payload is invalid', function () {
+    $response = await($this->signedPostRequest('events', null));
+
+    expect($response->getStatusCode())->toBe(500);
+})->throws(ResponseException::class, exceptionCode: 500);

--- a/tests/ReverbTestCase.php
+++ b/tests/ReverbTestCase.php
@@ -159,7 +159,7 @@ class ReverbTestCase extends TestCase
     /**
      * Send a POST request to the server.
      */
-    public function postReqeust(string $path, array $data = [], string $host = '0.0.0.0', string $port = '8080', string $appId = '123456'): PromiseInterface
+    public function postReqeust(string $path, ?array $data = [], string $host = '0.0.0.0', string $port = '8080', string $appId = '123456'): PromiseInterface
     {
         return $this->request($path, 'POST', $data, $host, $port, $appId);
     }
@@ -167,7 +167,7 @@ class ReverbTestCase extends TestCase
     /**
      * Send a signed POST request to the server.
      */
-    public function signedPostRequest(string $path, array $data = [], string $host = '0.0.0.0', string $port = '8080', string $appId = '123456'): PromiseInterface
+    public function signedPostRequest(string $path, ?array $data = [], string $host = '0.0.0.0', string $port = '8080', string $appId = '123456'): PromiseInterface
     {
         $hash = md5(json_encode($data));
         $timestamp = time();


### PR DESCRIPTION
This PR improves the exception handling and logging capabilities of Reverb by:

1. Using the `JSON_THROW_ON_ERROR` flag when decoding payloads
2. Logging exceptions before closing the connection with a 500 to provide visibility of the cause of the issue
3. Logging broadcast messages

<img width="974" alt="Screenshot 2024-04-04 at 10 17 10" src="https://github.com/laravel/reverb/assets/3438564/483e6911-f056-49c1-b1c1-22bdbff98932">

This PR replaces #119
