### PR TITLE
FIX: wrong calculation user_count on presence channels

### DIFF
--- a/src/Protocols/Pusher/Concerns/InteractsWithChannelInformation.php
+++ b/src/Protocols/Pusher/Concerns/InteractsWithChannelInformation.php
@@ -44,7 +44,14 @@ trait InteractsWithChannelInformation
      */
     private function occupiedInfo(Channel $channel, array $info): array
     {
-        $count = count($channel->connections());
+        if (in_array('user_count', $info) && $this->isPresenceChannel($channel)) {
+            $count = collect($channel->connections())
+                ->map(fn ($connection) => $connection->data())
+                ->unique('user_id')
+                ->count();
+        } else {
+            $count = count($channel->connections());
+        }
 
         return [
             'occupied' => in_array('occupied', $info) ? $count > 0 : null,

--- a/src/Protocols/Pusher/MetricsHandler.php
+++ b/src/Protocols/Pusher/MetricsHandler.php
@@ -107,6 +107,7 @@ class MetricsHandler
 
         return collect($channel->connections())
             ->map(fn ($connection) => $connection->data())
+            ->unique('user_id')
             ->map(fn ($data) => ['id' => $data['user_id']])
             ->values()
             ->all();


### PR DESCRIPTION
### user_count on get channels request

`$pusher->getChannels(['filter_by_prefix' => 'presence-', 'info' => 'user_count'])->channels` return wrong number for `user_count`.

If we check Pusher [documentation](https://pusher.com/docs/channels/library_auth_reference/rest-api/#request-2) we will see - `user_count` is number of distinct users currently subscribed to this channel (a single user may be subscribed many times, but will only count as one). So `user_count` must return only unique users count, not connections count.

### users list on get presence users request

`$pusher->getPresenceUsers('presence-channel-id');` return wrong list of users with duplicates for each connection. If we check Pusher [documentation](https://pusher.com/docs/channels/library_auth_reference/rest-api/#get-users) - fetch user IDs of user currently subscribed to a presence channel. Here must be only unique users, not connections.
