### PR TITLE
[1.x] Allow non-`Pusher` and `ClientEvent` messages

### DIFF
--- a/src/Protocols/Pusher/Server.php
+++ b/src/Protocols/Pusher/Server.php
@@ -52,15 +52,17 @@ class Server
         try {
             $event = json_decode($message, associative: true, flags: JSON_THROW_ON_ERROR);
 
-            match (Str::startsWith($event['event'], 'pusher:')) {
-                true => $this->handler->handle(
-                    $from,
-                    $event['event'],
-                    $event['data'] ?? [],
-                    $event['channel'] ?? null
-                ),
-                default => ClientEvent::handle($from, $event)
-            };
+            if (isset($event['event'])) {
+                match (Str::startsWith($event['event'], 'pusher:')) {
+                    true => $this->handler->handle(
+                        $from,
+                        $event['event'],
+                        $event['data'] ?? [],
+                        $event['channel'] ?? null
+                    ),
+                    default => ClientEvent::handle($from, $event)
+                };
+            }
 
             Log::info('Message Handled', $from->id());
 

--- a/src/Protocols/Pusher/Server.php
+++ b/src/Protocols/Pusher/Server.php
@@ -52,7 +52,7 @@ class Server
         try {
             $event = json_decode($message, associative: true, flags: JSON_THROW_ON_ERROR);
 
-            if (isset($event['event'])) {
+            if ( isset($event['event']) ) {
                 match (Str::startsWith($event['event'], 'pusher:')) {
                     true => $this->handler->handle(
                         $from,


### PR DESCRIPTION
Hey,

Love using Reverb so far! 🚀

I would like to use the websocket server to receive non-Laravel messages from other clients as well and handle the messages in my app. I have some IoT devices that allow for outbound websocket. 
The `MessageReceived` event is already implemented and I can just listen for it in the app. However it doesn't get executed because if the message doesn't contain the "event" key the server fails handling the message (`Undefined array key "event"`) and sends `'event' => 'pusher:error'` event to the client with message "Invalid message format".

We just need to check for the "event" key before using the `Pusher` or `ClientEvent` handler. 