### PR TITLE
Use secure redis connection if config is set to use TLS

### DIFF
--- a/src/Servers/Reverb/Publishing/RedisPubSubProvider.php
+++ b/src/Servers/Reverb/Publishing/RedisPubSubProvider.php
@@ -87,7 +87,7 @@ class RedisPubSubProvider implements PubSubProvider
     {
         $config = Config::get('database.redis.default');
 
-        [$host, $port, $query] = [
+        [$host, $port, $protocol, $query] = [
             $config['host'],
             $config['port'] ?: 6379,
             Arr::get($config, 'scheme') === 'tls' ? 's' : '',

--- a/src/Servers/Reverb/Publishing/RedisPubSubProvider.php
+++ b/src/Servers/Reverb/Publishing/RedisPubSubProvider.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Reverb\Servers\Reverb\Publishing;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Config;
 use Laravel\Reverb\Servers\Reverb\Contracts\PubSubIncomingMessageHandler;
 use Laravel\Reverb\Servers\Reverb\Contracts\PubSubProvider;
@@ -89,6 +90,7 @@ class RedisPubSubProvider implements PubSubProvider
         [$host, $port, $query] = [
             $config['host'],
             $config['port'] ?: 6379,
+            Arr::get($config, 'scheme') === 'tls' ? 's' : '',
             [],
         ];
 
@@ -102,7 +104,7 @@ class RedisPubSubProvider implements PubSubProvider
 
         $query = http_build_query($query);
 
-        return "redis://{$host}:{$port}".($query ? "?{$query}" : '');
+        return "redis{$protocol}://{$host}:{$port}".($query ? "?{$query}" : '');
     }
 
     /**


### PR DESCRIPTION
When using secure Redis connections with TLS, Reverb will only construct a TCP connection and could not re-use the existing TLS connection.

`rediss://` is the secure scheme when using TLS (See: https://www.iana.org/assignments/uri-schemes/prov/redis and also [`clue/reactphp-redis` repository](https://github.com/clue/reactphp-redis?#__construct))

This PR checks if the Redis connection has a `scheme` option with `tls` as value (as per Laravel's documentation) and add's the `s` to the connection URL.

**PS**: the `$protocol` variable name might not be the best choice so I'm open for suggestions on that.