### PR TITLE
[1.x] Handles stale app IDs

### DIFF
--- a/src/Protocols/Pusher/Http/Controllers/Controller.php
+++ b/src/Protocols/Pusher/Http/Controllers/Controller.php
@@ -46,12 +46,8 @@ abstract class Controller
         $this->body = $request->getBody()->getContents();
         $this->query = $query;
 
-        try {
-            $this->setApplication($appId);
-            $this->setChannels();
-        } catch (HttpException $e) {
-            $this->close($connection, $e->getStatusCode(), $e->getMessage());
-        }
+        $this->setApplication($appId);
+        $this->setChannels();
     }
 
     /**

--- a/src/Servers/Reverb/Http/Server.php
+++ b/src/Servers/Reverb/Http/Server.php
@@ -11,6 +11,7 @@ use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
 use React\Socket\ConnectionInterface;
 use React\Socket\ServerInterface;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Throwable;
 
 class Server
@@ -57,6 +58,8 @@ class Server
 
         try {
             $this->router->dispatch($request, $connection);
+        } catch (HttpException $e) {
+            $this->close($connection, $e->getStatusCode(), $e->getMessage());
         } catch (Throwable $e) {
             Log::error($e->getMessage());
             $this->close($connection, 500, 'Internal server error.');

--- a/tests/Feature/Protocols/Pusher/Reverb/EventsControllerTest.php
+++ b/tests/Feature/Protocols/Pusher/Reverb/EventsControllerTest.php
@@ -193,3 +193,7 @@ it('fails when payload is invalid', function () {
 
     expect($response->getStatusCode())->toBe(500);
 })->throws(ResponseException::class, exceptionCode: 500);
+
+it('fails when app cannot be found', function () {
+    await($this->signedPostRequest('events', appId: 'invalid-app-id'));
+})->throws(ResponseException::class, exceptionCode: 404);


### PR DESCRIPTION
This PR resolved #142 

We were catching an exception, but not stopping execution of the code which could result in a message being delivered when sent with an invalid app ID.

This could only really happen if you updated the App ID in your environment and immediately began broadcasting with the new App ID without restarting the Reverb server.

To address this, the exception is being caught higher up by the server instead of directly in the controller.