### PR TITLE
Fixed type error in connection message handler

### DIFF
--- a/src/Protocols/Pusher/Http/Controllers/PusherController.php
+++ b/src/Protocols/Pusher/Http/Controllers/PusherController.php
@@ -31,7 +31,7 @@ class PusherController
         $connection->withMaxMessageSize($reverbConnection->app()->maxMessageSize());
 
         $connection->onMessage(
-            fn ($message) => $this->server->message($reverbConnection, (string)$message)
+            fn ($message) => $this->server->message($reverbConnection, (string) $message)
         );
 
         $connection->onClose(

--- a/src/Protocols/Pusher/Http/Controllers/PusherController.php
+++ b/src/Protocols/Pusher/Http/Controllers/PusherController.php
@@ -31,7 +31,7 @@ class PusherController
         $connection->withMaxMessageSize($reverbConnection->app()->maxMessageSize());
 
         $connection->onMessage(
-            fn (string $message) => $this->server->message($reverbConnection, $message)
+            fn ($message) => $this->server->message($reverbConnection, (string)$message)
         );
 
         $connection->onClose(


### PR DESCRIPTION
I installed and setup Reverb (Laravel 11, PHP 8.3) and have been getting the same type error from the beginning when running the server:

```
Laravel\Reverb\Protocols\Pusher\Http\Controllers\PusherController::Laravel\Reverb\Protocols\Pusher\Http\Controllers\{closure}(): Argument #1 ($message) must be of type string, Ratchet\RFC6455\Messaging\Message given, called in .../app/vendor/ratchet/rfc6455/src/Messaging/MessageBuffer.php on line 254
```

Not sure why nobody else seems to be getting this error, but maybe something to do with strict typing as `Ratchet\RFC6455\Messaging\Message` is a stringable object. Anyways, just coercing `$message` to a string resolved the issue for me and I was getting successful pings after that.

All tests are still passing.