### PR TITLE
[1.x] Adds exists() method to ChannelManager

### DIFF
--- a/src/Protocols/Pusher/Contracts/ChannelManager.php
+++ b/src/Protocols/Pusher/Contracts/ChannelManager.php
@@ -31,7 +31,7 @@ interface ChannelManager
     public function find(string $channel): ?Channel;
 
     /**
-     * Check whether the channel exists or not.
+     * Determine whether the channel exists.
      */
     public function exists(string $channel): bool;
 

--- a/src/Protocols/Pusher/Contracts/ChannelManager.php
+++ b/src/Protocols/Pusher/Contracts/ChannelManager.php
@@ -31,7 +31,7 @@ interface ChannelManager
     public function find(string $channel): ?Channel;
 
     /**
-     * Determine whether the channel exists.
+     * Determine whether the given channel exists.
      */
     public function exists(string $channel): bool;
 

--- a/src/Protocols/Pusher/Contracts/ChannelManager.php
+++ b/src/Protocols/Pusher/Contracts/ChannelManager.php
@@ -26,14 +26,14 @@ interface ChannelManager
     public function all(): array;
 
     /**
-     * Find the given channel.
-     */
-    public function find(string $channel): ?Channel;
-
-    /**
      * Determine whether the given channel exists.
      */
     public function exists(string $channel): bool;
+
+    /**
+     * Find the given channel.
+     */
+    public function find(string $channel): ?Channel;
 
     /**
      * Find the given channel or create it if it doesn't exist.

--- a/src/Protocols/Pusher/Contracts/ChannelManager.php
+++ b/src/Protocols/Pusher/Contracts/ChannelManager.php
@@ -31,6 +31,11 @@ interface ChannelManager
     public function find(string $channel): ?Channel;
 
     /**
+     * Check whether the channel exists or not.
+     */
+    public function exists(string $channel): bool;
+
+    /**
      * Find the given channel or create it if it doesn't exist.
      */
     public function findOrCreate(string $channel): Channel;

--- a/src/Protocols/Pusher/Managers/ArrayChannelManager.php
+++ b/src/Protocols/Pusher/Managers/ArrayChannelManager.php
@@ -48,19 +48,19 @@ class ArrayChannelManager implements ChannelManagerInterface
     }
 
     /**
-     * Find the given channel
-     */
-    public function find(string $channel): ?Channel
-    {
-        return $this->channels($channel);
-    }
-
-    /**
      * Determine whether the given channel exists.
      */
     public function exists(string $channel): bool
     {
         return isset($this->applications[$this->application->id()][$channel]);
+    }
+
+    /**
+     * Find the given channel
+     */
+    public function find(string $channel): ?Channel
+    {
+        return $this->channels($channel);
     }
 
     /**

--- a/src/Protocols/Pusher/Managers/ArrayChannelManager.php
+++ b/src/Protocols/Pusher/Managers/ArrayChannelManager.php
@@ -56,7 +56,7 @@ class ArrayChannelManager implements ChannelManagerInterface
     }
 
     /**
-     * Determine whether the channel exists.
+     * Determine whether the given channel exists.
      */
     public function exists(string $channel): bool
     {

--- a/src/Protocols/Pusher/Managers/ArrayChannelManager.php
+++ b/src/Protocols/Pusher/Managers/ArrayChannelManager.php
@@ -55,6 +55,11 @@ class ArrayChannelManager implements ChannelManagerInterface
         return $this->channels($channel);
     }
 
+    public function exists(string $channel): bool
+    {
+        return isset($this->applications[$this->application->id()][$channel]);
+    }
+
     /**
      * Find the given channel or create it if it doesn't exist.
      */

--- a/src/Protocols/Pusher/Managers/ArrayChannelManager.php
+++ b/src/Protocols/Pusher/Managers/ArrayChannelManager.php
@@ -55,6 +55,9 @@ class ArrayChannelManager implements ChannelManagerInterface
         return $this->channels($channel);
     }
 
+    /**
+     * Determine whether the channel exists.
+     */
     public function exists(string $channel): bool
     {
         return isset($this->applications[$this->application->id()][$channel]);

--- a/tests/Unit/Protocols/Pusher/Managers/ChannelManagerTest.php
+++ b/tests/Unit/Protocols/Pusher/Managers/ChannelManagerTest.php
@@ -38,7 +38,7 @@ it('can get all channels', function () {
     expect($this->channelManager->all())->toHaveCount(4);
 });
 
-it('can determine if channel exists or not', function () {
+it('can determine whether a channel exists', function () {
     $this->channelManager->findOrCreate('test-channel-1');
 
     expect($this->channelManager->exists('test-channel-1'))->toBeTrue();

--- a/tests/Unit/Protocols/Pusher/Managers/ChannelManagerTest.php
+++ b/tests/Unit/Protocols/Pusher/Managers/ChannelManagerTest.php
@@ -38,6 +38,13 @@ it('can get all channels', function () {
     expect($this->channelManager->all())->toHaveCount(4);
 });
 
+it('can determine if channel exists or not', function () {
+    $this->channelManager->findOrCreate('test-channel-1');
+
+    expect($this->channelManager->exists('test-channel-1'))->toBeTrue();
+    expect($this->channelManager->exists('test-channel-2'))->toBeFalse();
+});
+
 it('can get all connections subscribed to a channel', function () {
     $connections = collect(factory(5))
         ->each(fn ($connection) => $this->channel->subscribe($connection->connection()));


### PR DESCRIPTION
I came across a situation in my project that needs to check if a channel exists or not.
We can utilize  `find()` method and check if the result is null or not; But since Reverb aims for performance, better to only check if key exists or not instead of loading object. It also gives freedom if someone wants to bind it's own `DbChannelManager` driver instead of `array`.