### PR TITLE
Dispatch event when connection is terminated

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -4,6 +4,7 @@ namespace Laravel\Reverb;
 
 use Laravel\Reverb\Concerns\GeneratesIdentifiers;
 use Laravel\Reverb\Contracts\Connection as ConnectionContract;
+use Laravel\Reverb\Events\ConnectionTerminated;
 use Laravel\Reverb\Events\MessageSent;
 
 class Connection extends ConnectionContract
@@ -56,5 +57,7 @@ class Connection extends ConnectionContract
     public function terminate(): void
     {
         $this->connection->close();
+
+        ConnectionTerminated::dispatch($this);
     }
 }

--- a/src/Events/ConnectionTerminated.php
+++ b/src/Events/ConnectionTerminated.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Laravel\Reverb\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Laravel\Reverb\Contracts\Connection;
+
+class ConnectionTerminated
+{
+    use Dispatchable;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(public Connection $connection)
+    {
+        //
+    }
+}


### PR DESCRIPTION
Hi,
I couldn't find a way to detect when connection is closed on **private** channel. Either by closing the browser tab or using 'pusher.disconnect()'.
The message is simply logged here:

https://github.com/laravel/reverb/blob/0b337bea0a1c471bc87ba2531ce63ba7da80705f/src/Protocols/Pusher/Server.php#L84
