### PR TITLE
[1.x] Handles Telescope ingest

### DIFF
--- a/config/reverb.php
+++ b/config/reverb.php
@@ -41,6 +41,7 @@ return [
                 'channel' => env('REVERB_SCALING_CHANNEL', 'reverb'),
             ],
             'pulse_ingest_interval' => env('REVERB_PULSE_INGEST_INTERVAL', 15),
+            'telescope_ingest_interval' => env('REVERB_TELESCOPE_INGEST_INTERVAL', 15),
         ],
 
     ],

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -14,4 +14,4 @@ parameters:
     - "#Parameter \\$livewire of anonymous function has invalid type#"
     - "#Class Laravel\\\\Pulse\\\\Pulse not found#"
     - "#Class Laravel\\\\Telescope\\\\Contracts\\\\EntriesRepository not found#"
-    - "#Call to static method store\(\) on an unknown class Laravel\\\\Telescope\\\\Telescope#"
+    - "#Call to static method store\\(\\) on an unknown class Laravel\\\\Telescope\\\\Telescope#"

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -14,4 +14,4 @@ parameters:
     - "#Parameter \\$livewire of anonymous function has invalid type#"
     - "#Class Laravel\\\\Pulse\\\\Pulse not found#"
     - "#Class Laravel\\\\Telescope\\\\Contracts\\\\EntriesRepository not found#"
-    - "#Call to static method store() on an unknown class Laravel\\\\Telescope\\\\Telescope#"
+    - "#Call to static method store\(\) on an unknown class Laravel\\\\Telescope\\\\Telescope#"

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -13,3 +13,5 @@ parameters:
     - "#\\(void\\) is used.#"
     - "#Parameter \\$livewire of anonymous function has invalid type#"
     - "#Class Laravel\\\\Pulse\\\\Pulse not found#"
+    - "#Class Laravel\\\\Telescope\\\\Contracts\\\\EntriesRepository not found#"
+    - "#Call to static method store() on an unknown class Laravel\\\\Telescope\\\\Telescope#"


### PR DESCRIPTION
This PR resolves #148 

Telescope works by stroing events after a response has been sent or a job processed. With Reverb, neither of these things happen so Telescope entries accumulate causing in memory consumption.

This PR attempts to address that by periodically storing and flushing the buffer of entries in a similar approach to Pulse.