### PR TITLE
[1.x] Improve TLS check

### DIFF
--- a/src/Servers/Reverb/Factory.php
+++ b/src/Servers/Reverb/Factory.php
@@ -53,7 +53,7 @@ class Factory
 
         $options['tls'] = static::configureTls($options['tls'] ?? [], $hostname);
 
-        $uri = empty($options['tls']) ? "{$host}:{$port}" : "tls://{$host}:{$port}";
+        $uri = static::usesTls($options['tls']) ? "{$host}:{$port}" : "tls://{$host}:{$port}";
 
         return new HttpServer(
             new SocketServer($uri, $options, $loop),
@@ -115,9 +115,7 @@ class Factory
     {
         $context = array_filter($context, fn ($value) => $value !== null);
 
-        $usesTls = ($context['local_cert'] ?? false) || ($context['local_pk'] ?? false);
-
-        if (! $usesTls && $hostname && Certificate::exists($hostname)) {
+        if (! static::usesTls($context) && $hostname && Certificate::exists($hostname)) {
             [$certificate, $key] = Certificate::resolve($hostname);
 
             $context['local_cert'] = $certificate;
@@ -125,5 +123,15 @@ class Factory
         }
 
         return $context;
+    }
+
+    /**
+     * Determine whether the server uses TLS.
+     *
+     * @param  array  $context<string,  mixed>
+     */
+    protected static function usesTls(array $context): bool
+    {
+        return ($context['local_cert'] ?? false) || ($context['local_pk'] ?? false);
     }
 }


### PR DESCRIPTION
This PR resolves #155 

Currently we check whether the SSL context is empty, which allows users to use environment variables to toggle SSL support between environments.

However, that requires all SSL context options to be `null`, but we are only really interested in checking `local_cert` and `local_pk`.

Other variables can be set and not impact whether or not the server is started securely.