### PR TITLE
[1.x] Fixes SSL connection issues in Chrome / Arc

### DIFF
--- a/src/Servers/Reverb/Factory.php
+++ b/src/Servers/Reverb/Factory.php
@@ -122,7 +122,7 @@ class Factory
 
             $context['local_cert'] = $certificate;
             $context['local_pk'] = $key;
-            $context['verify_peer'] = false;
+            $context['verify_peer'] = app()->environment() === 'production';
         }
 
         return $context;

--- a/src/Servers/Reverb/Factory.php
+++ b/src/Servers/Reverb/Factory.php
@@ -122,6 +122,7 @@ class Factory
 
             $context['local_cert'] = $certificate;
             $context['local_pk'] = $key;
+            $context['verify_peer'] = false;
         }
 
         return $context;


### PR DESCRIPTION
When used with secure sites on Valet or Herd, Reverb will automatically discover the certificate and use it to enable secure WebSocket connections.

This works nicely, but there are issues in Chrome.

If you use Echo to connect over wss, Chrome will reject the connection without any useful reason why.

What's even more strange is if you navigate to https://site.test:8080 in the browser, Reverb will load the page with no SSL error.

After doing so, attempting to connect via Echo again (wss://site.test:8080), results in a successful connection 🤷

I was able to go deep into Chrome and review the logs which exposed an error: `ERR_SSL_CLIENT_AUTH_CERT_NEEDED`

This indicates an issue in the SSL handshake between client and server. The server doesn't trust the certificate being used by the client - strange because it works fine over https.

By disabling peer verification, the handshake completes successfully.

I still believe this to be an issue with the browser, but this does resolve the issue and I don't really see an issue with disabling `verify_peer` in local development.

