### PR TITLE
[1.x] Improves check for Telescope

### DIFF
--- a/src/Servers/Reverb/Console/Commands/StartServer.php
+++ b/src/Servers/Reverb/Console/Commands/StartServer.php
@@ -151,7 +151,7 @@ class StartServer extends Command implements SignalableCommandInterface
      */
     protected function ensureTelescopeEntriesAreCollected(LoopInterface $loop, int $interval): void
     {
-        if (! class_exists(\Laravel\Telescope\Telescope::class)) {
+        if (! $this->laravel->bound(\Laravel\Telescope\Contracts\EntriesRepository::class)) {
             return;
         }
 


### PR DESCRIPTION
It was pointed out to me that it's recommended in the docs to have Telescope installed, but toggle the service provider depending on the environment.

This means although `\Laravel\Telescope\Telescope::class` is available in the project, `\Laravel\Telescope\Contracts\EntriesRepository::class` is not bound.

This PR updates the check for the bound class instead.
