### PR TITLE
Add configuration for Redis cluster support

### DIFF
--- a/config/reverb.php
+++ b/config/reverb.php
@@ -39,7 +39,14 @@ return [
             'scaling' => [
                 'enabled' => env('REVERB_SCALING_ENABLED', false),
                 'channel' => env('REVERB_SCALING_CHANNEL', 'reverb'),
-                'cluster_enabled' => env('REVERB_SCALING_CLUSTER_ENABLED', false),
+                'server' => [
+                    'url' => env('REDIS_URL'),
+                    'host' => env('REDIS_HOST', '127.0.0.1'),
+                    'username' => env('REDIS_USERNAME'),
+                    'password' => env('REDIS_PASSWORD'),
+                    'port' => env('REDIS_PORT', '6379'),
+                    'database' => env('REDIS_DB', '0'),
+                ],
             ],
             'pulse_ingest_interval' => env('REVERB_PULSE_INGEST_INTERVAL', 15),
             'telescope_ingest_interval' => env('REVERB_TELESCOPE_INGEST_INTERVAL', 15),

--- a/config/reverb.php
+++ b/config/reverb.php
@@ -39,6 +39,7 @@ return [
             'scaling' => [
                 'enabled' => env('REVERB_SCALING_ENABLED', false),
                 'channel' => env('REVERB_SCALING_CHANNEL', 'reverb'),
+                'cluster_enabled' => env('REVERB_SCALING_CLUSTER_ENABLED', false),
             ],
             'pulse_ingest_interval' => env('REVERB_PULSE_INGEST_INTERVAL', 15),
             'telescope_ingest_interval' => env('REVERB_TELESCOPE_INGEST_INTERVAL', 15),

--- a/config/reverb.php
+++ b/config/reverb.php
@@ -40,11 +40,9 @@ return [
                 'enabled' => env('REVERB_SCALING_ENABLED', false),
                 'channel' => env('REVERB_SCALING_CHANNEL', 'reverb'),
                 'server' => [
-                    'url' => env('REDIS_URL'),
                     'host' => env('REDIS_HOST', '127.0.0.1'),
-                    'username' => env('REDIS_USERNAME'),
-                    'password' => env('REDIS_PASSWORD'),
                     'port' => env('REDIS_PORT', '6379'),
+                    'password' => env('REDIS_PASSWORD'),
                     'database' => env('REDIS_DB', '0'),
                 ],
             ],

--- a/src/Servers/Reverb/Publishing/RedisPubSubProvider.php
+++ b/src/Servers/Reverb/Publishing/RedisPubSubProvider.php
@@ -20,7 +20,7 @@ class RedisPubSubProvider implements PubSubProvider
         protected RedisClientFactory $clientFactory,
         protected PubSubIncomingMessageHandler $messageHandler,
         protected string $channel,
-        protected bool $clusterMode = false
+        protected array $server = []
     ) {
         //
     }
@@ -86,7 +86,7 @@ class RedisPubSubProvider implements PubSubProvider
      */
     protected function redisUrl(): string
     {
-        $config = Config::get($this->clusterMode ? 'database.redis.clusters.default.0' : 'database.redis.default');
+        $config = empty($this->server) ? Config::get('database.redis.default') : $this->server;
 
         [$host, $port, $protocol, $query] = [
             $config['host'],

--- a/src/Servers/Reverb/Publishing/RedisPubSubProvider.php
+++ b/src/Servers/Reverb/Publishing/RedisPubSubProvider.php
@@ -19,7 +19,8 @@ class RedisPubSubProvider implements PubSubProvider
     public function __construct(
         protected RedisClientFactory $clientFactory,
         protected PubSubIncomingMessageHandler $messageHandler,
-        protected string $channel
+        protected string $channel,
+        protected bool $clusterMode = false
     ) {
         //
     }
@@ -85,7 +86,7 @@ class RedisPubSubProvider implements PubSubProvider
      */
     protected function redisUrl(): string
     {
-        $config = Config::get('database.redis.default');
+        $config = Config::get($this->clusterMode ? 'database.redis.clusters.default.0' : 'database.redis.default');
 
         [$host, $port, $protocol, $query] = [
             $config['host'],

--- a/src/Servers/Reverb/ReverbServerProvider.php
+++ b/src/Servers/Reverb/ReverbServerProvider.php
@@ -38,7 +38,7 @@ class ReverbServerProvider extends ServerProvider
             $app->make(RedisClientFactory::class),
             $app->make(PubSubIncomingMessageHandler::class),
             $this->config['scaling']['channel'] ?? 'reverb',
-            $this->config['scaling']['cluster_enabled'] ?? false
+            $this->config['scaling']['server'] ?? []
         ));
     }
 

--- a/src/Servers/Reverb/ReverbServerProvider.php
+++ b/src/Servers/Reverb/ReverbServerProvider.php
@@ -37,7 +37,8 @@ class ReverbServerProvider extends ServerProvider
         $this->app->singleton(PubSubProvider::class, fn ($app) => new RedisPubSubProvider(
             $app->make(RedisClientFactory::class),
             $app->make(PubSubIncomingMessageHandler::class),
-            $this->config['scaling']['channel'] ?? 'reverb'
+            $this->config['scaling']['channel'] ?? 'reverb',
+            $this->config['scaling']['cluster_enabled'] ?? false
         ));
     }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This adds a configuration setting and check to allow Redis in cluster mode (see issue #160). Adding `REVERB_SCALING_CLUSTER_ENABLED=true` to the `.env` file will change the config used from `database.redis.default` to `database.redis.clusters.default.0`. Like the horizontal scaling feature, this is off by default.