### PR TITLE
Fix accessing potentially undefined array key

### DIFF
--- a/src/Protocols/Pusher/Http/Controllers/ChannelController.php
+++ b/src/Protocols/Pusher/Http/Controllers/ChannelController.php
@@ -19,7 +19,7 @@ class ChannelController extends Controller
 
         return app(MetricsHandler::class)->gather($this->application, 'channel', [
             'channel' => $channel,
-            'info' => ($info = $this->query['info']) ? $info.',occupied' : 'occupied',
+            'info' => isset($this->query['info']) ? $this->query['info'].',occupied' : 'occupied',
         ])->then(fn ($channel) => new Response((object) $channel));
     }
 }


### PR DESCRIPTION
Currently calling `getChannelInfo()` without `info` will lead to "500 Internal Server Error" with the error message `[ERROR] Undefined array key "info"`. The PR fixes this.
