### PR TITLE
Cast content length to string when setting headers in HTTP Response.php

### DIFF
--- a/src/Servers/Reverb/Http/Response.php
+++ b/src/Servers/Reverb/Http/Response.php
@@ -13,6 +13,6 @@ class Response extends JsonResponse
     {
         parent::__construct($data, $status, $headers, $json);
 
-        $this->headers->set('Content-Length', strlen($this->content));
+        $this->headers->set('Content-Length', (string) strlen($this->content));
     }
 }


### PR DESCRIPTION
The header function inside the JsonResponse class expects array|null|string and previously we were passing an integer.

I see little reason in not sticking to the variable types defined in the json response's set function.

Pedantic change but strict types can now be used
