### PR TITLE
Add health check endpoint (laravel#190)

### DIFF
--- a/src/Protocols/Pusher/Http/Controllers/HealthCheckController.php
+++ b/src/Protocols/Pusher/Http/Controllers/HealthCheckController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Laravel\Reverb\Protocols\Pusher\Http\Controllers;
+
+use Laravel\Reverb\Servers\Reverb\Http\Connection;
+use Laravel\Reverb\Servers\Reverb\Http\Response;
+use Psr\Http\Message\RequestInterface;
+
+class HealthCheckController extends Controller
+{
+    /**
+     * Handle the request.
+     */
+    public function __invoke(RequestInterface $request, Connection $connection): Response
+    {
+        return new Response((object) ['health' => 'OK']);
+    }
+}

--- a/src/Servers/Reverb/Factory.php
+++ b/src/Servers/Reverb/Factory.php
@@ -13,6 +13,7 @@ use Laravel\Reverb\Protocols\Pusher\Http\Controllers\ChannelUsersController;
 use Laravel\Reverb\Protocols\Pusher\Http\Controllers\ConnectionsController;
 use Laravel\Reverb\Protocols\Pusher\Http\Controllers\EventsBatchController;
 use Laravel\Reverb\Protocols\Pusher\Http\Controllers\EventsController;
+use Laravel\Reverb\Protocols\Pusher\Http\Controllers\HealthCheckController;
 use Laravel\Reverb\Protocols\Pusher\Http\Controllers\PusherController;
 use Laravel\Reverb\Protocols\Pusher\Http\Controllers\UsersTerminateController;
 use Laravel\Reverb\Protocols\Pusher\Managers\ArrayChannelConnectionManager;
@@ -101,6 +102,7 @@ class Factory
         $routes->add('channel', Route::get('/apps/{appId}/channels/{channel}', new ChannelController));
         $routes->add('channel_users', Route::get('/apps/{appId}/channels/{channel}/users', new ChannelUsersController));
         $routes->add('users_terminate', Route::post('/apps/{appId}/users/{userId}/terminate_connections', new UsersTerminateController));
+        $routes->add('health_check', Route::get('/up', new HealthCheckController));
 
         return $routes;
     }

--- a/tests/Feature/Protocols/Pusher/Reverb/HealthCheckControllerTest.php
+++ b/tests/Feature/Protocols/Pusher/Reverb/HealthCheckControllerTest.php
@@ -1,0 +1,20 @@
+<?php
+
+use Laravel\Reverb\Tests\ReverbTestCase;
+
+use function React\Async\await;
+
+uses(ReverbTestCase::class);
+
+it('fails when server is not running', function () {
+    $this->stopServer();
+    await($this->requestWithoutAppId('up'));
+})->throws(RuntimeException::class);
+
+it('can respond to a health check request', function () {
+    $response = await($this->requestWithoutAppId('up'));
+
+    expect($response->getStatusCode())->toBe(200);
+    expect($response->getBody()->getContents())->toBe('{"health":"OK"}');
+    expect($response->getHeader('Content-Length'))->toBe(['15']);
+});

--- a/tests/ReverbTestCase.php
+++ b/tests/ReverbTestCase.php
@@ -142,6 +142,20 @@ class ReverbTestCase extends TestCase
     }
 
     /**
+     * Send a request to the server without specifying app ID.
+     */
+    public function requestWithoutAppId(string $path, string $method = 'GET', mixed $data = '', string $host = '0.0.0.0', string $port = '8080'): PromiseInterface
+    {
+        return (new Browser($this->loop))
+            ->request(
+                $method,
+                "http://{$host}:{$port}/{$path}",
+                [],
+                ($data) ? json_encode($data) : ''
+            );
+    }
+
+    /**
      * Send a signed request to the server.
      */
     public function signedRequest(string $path, string $method = 'GET', mixed $data = '', string $host = '0.0.0.0', string $port = '8080', string $appId = '123456'): PromiseInterface


### PR DESCRIPTION
New `/health_check` endpoint will be available when Reverb server is running, that will response with `{"health":"OK"}` to support k8s HTTP health checks required by some cloud provider Load Balancers (i.e. GCP)