### PR TITLE
[1.x] Retrieves applications from provider in Pulse connections recorder

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -77,6 +77,11 @@ class Application
         return $this->options;
     }
 
+    /**
+     * Convert the application to an array.
+     *
+     * @return array<string, mixed>
+     */
     public function toArray(): array
     {
         return [

--- a/src/Application.php
+++ b/src/Application.php
@@ -14,6 +14,7 @@ class Application
         protected int $pingInterval,
         protected array $allowedOrigins,
         protected int $maxMessageSize,
+        protected array $options = [],
     ) {
         //
     }
@@ -66,5 +67,26 @@ class Application
     public function maxMessageSize(): int
     {
         return $this->maxMessageSize;
+    }
+
+    /**
+     * Get the application options.
+     */
+    public function options(): ?array
+    {
+        return $this->options;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'app_id' => $this->id,
+            'key' => $this->key,
+            'secret' => $this->secret,
+            'ping_interval' => $this->pingInterval,
+            'allowed_origins' => $this->allowedOrigins,
+            'max_message_size' => $this->maxMessageSize,
+            'options' => $this->options,
+        ];
     }
 }

--- a/src/ConfigApplicationProvider.php
+++ b/src/ConfigApplicationProvider.php
@@ -68,6 +68,7 @@ class ConfigApplicationProvider implements ApplicationProvider
             $app['ping_interval'],
             $app['allowed_origins'],
             $app['max_message_size'],
+            $app['options'],
         );
     }
 }

--- a/src/ConfigApplicationProvider.php
+++ b/src/ConfigApplicationProvider.php
@@ -69,7 +69,7 @@ class ConfigApplicationProvider implements ApplicationProvider
             $app['ping_interval'],
             $app['allowed_origins'],
             $app['max_message_size'],
-            Arr::get($app, 'options', []),
+            $app['options'] ?? [],
         );
     }
 }

--- a/src/ConfigApplicationProvider.php
+++ b/src/ConfigApplicationProvider.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Reverb;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Laravel\Reverb\Contracts\ApplicationProvider;
 use Laravel\Reverb\Exceptions\InvalidApplication;
@@ -68,7 +69,7 @@ class ConfigApplicationProvider implements ApplicationProvider
             $app['ping_interval'],
             $app['allowed_origins'],
             $app['max_message_size'],
-            $app['options'],
+            Arr::get($app, 'options', []),
         );
     }
 }

--- a/src/ConfigApplicationProvider.php
+++ b/src/ConfigApplicationProvider.php
@@ -2,7 +2,6 @@
 
 namespace Laravel\Reverb;
 
-use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Laravel\Reverb\Contracts\ApplicationProvider;
 use Laravel\Reverb\Exceptions\InvalidApplication;

--- a/src/Pulse/Recorders/ReverbConnections.php
+++ b/src/Pulse/Recorders/ReverbConnections.php
@@ -50,7 +50,7 @@ class ReverbConnections
 
                 $this->pulse->record(
                     type: 'reverb_connections',
-                    key: $app['app_id'],
+                    key: $app->id(),
                     value: $connections,
                     timestamp: $event->time->getTimestamp(),
                 )->avg()->max()->onlyBuckets();

--- a/src/Pulse/Recorders/ReverbConnections.php
+++ b/src/Pulse/Recorders/ReverbConnections.php
@@ -3,7 +3,6 @@
 namespace Laravel\Reverb\Pulse\Recorders;
 
 use Illuminate\Broadcasting\BroadcastManager;
-use Illuminate\Config\Repository;
 use Illuminate\Contracts\Foundation\Application as Container;
 use Laravel\Pulse\Events\IsolatedBeat;
 use Laravel\Pulse\Pulse;

--- a/src/Pulse/Recorders/ReverbConnections.php
+++ b/src/Pulse/Recorders/ReverbConnections.php
@@ -4,9 +4,12 @@ namespace Laravel\Reverb\Pulse\Recorders;
 
 use Illuminate\Broadcasting\BroadcastManager;
 use Illuminate\Config\Repository;
+use Illuminate\Contracts\Foundation\Application as Container;
 use Laravel\Pulse\Events\IsolatedBeat;
 use Laravel\Pulse\Pulse;
 use Laravel\Pulse\Recorders\Concerns\Sampling;
+use Laravel\Reverb\Application;
+use Laravel\Reverb\Contracts\ApplicationProvider;
 
 class ReverbConnections
 {
@@ -25,7 +28,7 @@ class ReverbConnections
     public function __construct(
         protected Pulse $pulse,
         protected BroadcastManager $broadcast,
-        protected Repository $config,
+        protected Container $app,
     ) {
         //
     }
@@ -39,17 +42,18 @@ class ReverbConnections
             return;
         }
 
-        foreach ($this->config->get('reverb.apps.apps') as $app) {
-            $connections = $this->broadcast->pusher($app)
-                ->get('/connections')
-                ->connections;
+        $this->app->make(ApplicationProvider::class)->all()
+            ->each(function (Application $app) use ($event) {
+                $connections = $this->broadcast->pusher($app->toArray())
+                    ->get('/connections')
+                    ->connections;
 
-            $this->pulse->record(
-                type: 'reverb_connections',
-                key: $app['app_id'],
-                value: $connections,
-                timestamp: $event->time->getTimestamp(),
-            )->avg()->max()->onlyBuckets();
-        }
+                $this->pulse->record(
+                    type: 'reverb_connections',
+                    key: $app['app_id'],
+                    value: $connections,
+                    timestamp: $event->time->getTimestamp(),
+                )->avg()->max()->onlyBuckets();
+            });
     }
 }

--- a/tests/FakeApplicationProvider.php
+++ b/tests/FakeApplicationProvider.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Laravel\Reverb\Tests;
+
+use Illuminate\Support\Collection;
+use Laravel\Reverb\Application;
+use Laravel\Reverb\Contracts\ApplicationProvider;
+
+class FakeApplicationProvider implements ApplicationProvider  {
+
+    protected $apps;
+
+    public function __construct()
+    {
+        $this->apps = collect([
+            new Application('id', 'key', 'secret', 60, ['*'], 10_000, [
+                'host' => 'localhost',
+                'port' => 443,
+                'scheme' => 'https',
+                'useTLS' => true,
+            ])
+        ]);
+    }
+
+    public function all(): Collection
+    {
+        return $this->apps;
+    }
+
+    public function findById(string $id): Application
+    {
+        return $this->apps->first();
+    }
+
+    public function findByKey(string $key): Application
+    {
+        return $this->apps->first();
+    }
+}

--- a/tests/FakeApplicationProvider.php
+++ b/tests/FakeApplicationProvider.php
@@ -6,8 +6,8 @@ use Illuminate\Support\Collection;
 use Laravel\Reverb\Application;
 use Laravel\Reverb\Contracts\ApplicationProvider;
 
-class FakeApplicationProvider implements ApplicationProvider  {
-
+class FakeApplicationProvider implements ApplicationProvider
+{
     protected $apps;
 
     public function __construct()
@@ -18,7 +18,7 @@ class FakeApplicationProvider implements ApplicationProvider  {
                 'port' => 443,
                 'scheme' => 'https',
                 'useTLS' => true,
-            ])
+            ]),
         ]);
     }
 

--- a/tests/FakeApplicationProvider.php
+++ b/tests/FakeApplicationProvider.php
@@ -8,8 +8,16 @@ use Laravel\Reverb\Contracts\ApplicationProvider;
 
 class FakeApplicationProvider implements ApplicationProvider
 {
+    /**
+     * The applications collection.
+     *
+     * @var \Illuminate\Support\Collection<\Laravel\Reverb\Application>
+     */
     protected $apps;
 
+    /**
+     * Create a new fake provider instance.
+     */
     public function __construct()
     {
         $this->apps = collect([
@@ -22,16 +30,31 @@ class FakeApplicationProvider implements ApplicationProvider
         ]);
     }
 
+    /**
+     * Get all of the configured applications as Application instances.
+     *
+     * @return \Illuminate\Support\Collection<\Laravel\Reverb\Application>
+     */
     public function all(): Collection
     {
         return $this->apps;
     }
 
+    /**
+     * Find an application instance by ID.
+     *
+     * @throws \Laravel\Reverb\Exceptions\InvalidApplication
+     */
     public function findById(string $id): Application
     {
         return $this->apps->first();
     }
 
+    /**
+     * Find an application instance by key.
+     *
+     * @throws \Laravel\Reverb\Exceptions\InvalidApplication
+     */
     public function findByKey(string $key): Application
     {
         return $this->apps->first();

--- a/tests/Unit/ProviderTest.php
+++ b/tests/Unit/ProviderTest.php
@@ -1,17 +1,16 @@
 <?php
 
-use Illuminate\Support\Collection;
 use Laravel\Reverb\Application;
 use Laravel\Reverb\ApplicationManager;
 use Laravel\Reverb\Contracts\ApplicationProvider;
 use Laravel\Reverb\Tests\FakeApplicationProvider;
 
-it('retrieves applications from custom provider', function() {
-    $this->app->make(ApplicationManager::class)->extend('fake', fn() => new FakeApplicationProvider);
+it('retrieves applications from custom provider', function () {
+    $this->app->make(ApplicationManager::class)->extend('fake', fn () => new FakeApplicationProvider);
 
     config([
         'reverb.apps.provider' => 'fake',
-        'reverb.apps.apps' => []
+        'reverb.apps.apps' => [],
     ]);
 
     $applicationsProvider = $this->app->make(ApplicationProvider::class);
@@ -31,6 +30,6 @@ it('retrieves applications from custom provider', function() {
                 'port' => 443,
                 'scheme' => 'https',
                 'useTLS' => true,
-            ]
+            ],
         ]);
 });

--- a/tests/Unit/ProviderTest.php
+++ b/tests/Unit/ProviderTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Support\Collection;
+use Laravel\Reverb\Application;
+use Laravel\Reverb\ApplicationManager;
+use Laravel\Reverb\Contracts\ApplicationProvider;
+use Laravel\Reverb\Tests\FakeApplicationProvider;
+
+it('retrieves applications from custom provider', function() {
+    $this->app->make(ApplicationManager::class)->extend('fake', fn() => new FakeApplicationProvider);
+
+    config([
+        'reverb.apps.provider' => 'fake',
+        'reverb.apps.apps' => []
+    ]);
+
+    $applicationsProvider = $this->app->make(ApplicationProvider::class);
+    $application = $applicationsProvider->all()->first();
+
+    expect($applicationsProvider->all())->toHaveLength(1)
+        ->and($application)->toBeInstanceOf(Application::class)
+        ->and($application->toArray())->toMatchArray([
+            'app_id' => 'id',
+            'key' => 'key',
+            'secret' => 'secret',
+            'ping_interval' => 60,
+            'allowed_origins' => ['*'],
+            'max_message_size' => 10_000,
+            'options' => [
+                'host' => 'localhost',
+                'port' => 443,
+                'scheme' => 'https',
+                'useTLS' => true,
+            ]
+        ]);
+});


### PR DESCRIPTION
This PR updates how the connections recorder for Pulse retrieves applications. It now retrieves them from the registered ApplicationProvider. This extends the Application constructor with the options array.

Currently, the connections recorder does not work with providers other than the config provider. Another potential provider could be a database provider.

Let me know if you are willing to accept this kind of PR. I am happy to add test cases for this or update the PR.