### PR TITLE
[1.x] Prevents blocking event loop

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "laravel/prompts": "^0.1.15",
         "pusher/pusher-php-server": "^7.2",
         "ratchet/rfc6455": "^0.3.1",
+        "react/async": "^4.2",
         "react/promise-timer": "^1.10",
         "react/socket": "^1.14",
         "symfony/console": "^6.0|^7.0",
@@ -39,7 +40,6 @@
         "pestphp/pest": "^2.0",
         "phpstan/phpstan": "^1.10",
         "ratchet/pawl": "^0.4.1",
-        "react/async": "^4.0",
         "react/http": "^1.9"
     },
     "autoload": {

--- a/src/Servers/Reverb/Http/Server.php
+++ b/src/Servers/Reverb/Http/Server.php
@@ -27,7 +27,7 @@ class Server
 
         $this->loop = $loop ?: Loop::get();
 
-        $this->loop->addPeriodicTimer(30, fn () => gc_collect_cycles());
+        $this->loop->addPeriodicTimer(30, \React\Async\async(fn () => gc_collect_cycles()));
 
         // Register __invoke handler for this class to receive new connections...
         $socket->on('connection', $this);


### PR DESCRIPTION
ReactPHP runs in one thread and can't be interrupted. So, when we have some blocking stuff inside one of the handlers, for example connection to Redis not stable, or turn on xDebug make garbage collector slower than usual, the whole loop is blocked, and all other handlers will be delayed!
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
