### PR TITLE
Revert #195

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
         "laravel/prompts": "^0.1.15",
         "pusher/pusher-php-server": "^7.2",
         "ratchet/rfc6455": "^0.3.1",
-        "react/async": "^4.2",
         "react/promise-timer": "^1.10",
         "react/socket": "^1.14",
         "symfony/console": "^6.0|^7.0",
@@ -40,6 +39,7 @@
         "pestphp/pest": "^2.0",
         "phpstan/phpstan": "^1.10",
         "ratchet/pawl": "^0.4.1",
+        "react/async": "^4.2",
         "react/http": "^1.9"
     },
     "autoload": {

--- a/src/Servers/Reverb/Console/Commands/StartServer.php
+++ b/src/Servers/Reverb/Console/Commands/StartServer.php
@@ -20,8 +20,6 @@ use React\EventLoop\LoopInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\SignalableCommandInterface;
 
-use function React\Async\async;
-
 #[AsCommand(name: 'reverb:start')]
 class StartServer extends Command implements SignalableCommandInterface
 {
@@ -92,10 +90,10 @@ class StartServer extends Command implements SignalableCommandInterface
      */
     protected function ensureStaleConnectionsAreCleaned(LoopInterface $loop): void
     {
-        $loop->addPeriodicTimer(60, async(function () {
+        $loop->addPeriodicTimer(60, function () {
             PruneStaleConnections::dispatch();
             PingInactiveConnections::dispatch();
-        }));
+        });
     }
 
     /**
@@ -105,7 +103,7 @@ class StartServer extends Command implements SignalableCommandInterface
     {
         $lastRestart = Cache::get('laravel:reverb:restart');
 
-        $loop->addPeriodicTimer(5, async(function () use ($server, $host, $port, $lastRestart) {
+        $loop->addPeriodicTimer(5, function () use ($server, $host, $port, $lastRestart) {
             if ($lastRestart === Cache::get('laravel:reverb:restart')) {
                 return;
             }
@@ -115,7 +113,7 @@ class StartServer extends Command implements SignalableCommandInterface
             $server->stop();
 
             $this->components->info("Stopping server on {$host}:{$port}");
-        }));
+        });
     }
 
     /**
@@ -143,9 +141,9 @@ class StartServer extends Command implements SignalableCommandInterface
             return;
         }
 
-        $loop->addPeriodicTimer($interval, async(function () {
+        $loop->addPeriodicTimer($interval, function () {
             $this->laravel->make(\Laravel\Pulse\Pulse::class)->ingest();
-        }));
+        });
     }
 
     /**
@@ -157,9 +155,9 @@ class StartServer extends Command implements SignalableCommandInterface
             return;
         }
 
-        $loop->addPeriodicTimer($interval, async(function () {
+        $loop->addPeriodicTimer($interval, function () {
             \Laravel\Telescope\Telescope::store($this->laravel->make(\Laravel\Telescope\Contracts\EntriesRepository::class));
-        }));
+        });
     }
 
     /**

--- a/src/Servers/Reverb/Http/Server.php
+++ b/src/Servers/Reverb/Http/Server.php
@@ -27,7 +27,7 @@ class Server
 
         $this->loop = $loop ?: Loop::get();
 
-        $this->loop->addPeriodicTimer(30, \React\Async\async(fn () => gc_collect_cycles()));
+        $this->loop->addPeriodicTimer(30, fn () => gc_collect_cycles());
 
         // Register __invoke handler for this class to receive new connections...
         $socket->on('connection', $this);


### PR DESCRIPTION
Wrapping a callback function with `async()` only makes sense when combined with `await()` or we want to return a promise. `gc_collect_cycles()` is a blocking function and wrapping `async()` does not make it non-blocking.

See: https://github.com/laravel/reverb/pull/195#issuecomment-2132613234
