### PR TITLE
[1.x] Correctly dispatches presence events

### DIFF
--- a/src/Protocols/Pusher/Channels/Concerns/InteractsWithPresenceChannels.php
+++ b/src/Protocols/Pusher/Channels/Concerns/InteractsWithPresenceChannels.php
@@ -58,7 +58,8 @@ trait InteractsWithPresenceChannels
     public function data(): array
     {
         $connections = collect($this->connections->all())
-            ->map(fn ($connection) => $connection->data());
+            ->map(fn ($connection) => $connection->data())
+            ->unique('user_id');
 
         if ($connections->contains(fn ($connection) => ! isset($connection['user_id']))) {
             return [

--- a/src/Protocols/Pusher/Channels/Concerns/InteractsWithPresenceChannels.php
+++ b/src/Protocols/Pusher/Channels/Concerns/InteractsWithPresenceChannels.php
@@ -15,12 +15,20 @@ trait InteractsWithPresenceChannels
     {
         $this->verify($connection, $auth, $data);
 
+        $userData = $data ? json_decode($data, associative: true, flags: JSON_THROW_ON_ERROR) : [];
+
+        if ($this->userIsSubscribed($userData['user_id'] ?? null)) {
+            parent::subscribe($connection, $auth, $data);
+
+            return;
+        }
+
         parent::subscribe($connection, $auth, $data);
 
         parent::broadcastInternally(
             [
                 'event' => 'pusher_internal:member_added',
-                'data' => $data ? json_decode($data, associative: true, flags: JSON_THROW_ON_ERROR) : [],
+                'data' => $userData,
                 'channel' => $this->name(),
             ],
             $connection
@@ -32,24 +40,26 @@ trait InteractsWithPresenceChannels
      */
     public function unsubscribe(Connection $connection): void
     {
-        if (! $subscription = $this->connections->find($connection)) {
-            parent::unsubscribe($connection);
+        $subscription = $this->connections->find($connection);
 
+        parent::unsubscribe($connection);
+
+        if (
+            ! $subscription ||
+            ! $subscription->data('user_id') ||
+            $this->userIsSubscribed($subscription->data('user_id'))
+        ) {
             return;
         }
 
-        if ($userId = $subscription->data('user_id')) {
-            parent::broadcast(
-                [
-                    'event' => 'pusher_internal:member_removed',
-                    'data' => ['user_id' => $userId],
-                    'channel' => $this->name(),
-                ],
-                $connection
-            );
-        }
-
-        parent::unsubscribe($connection);
+        parent::broadcast(
+            [
+                'event' => 'pusher_internal:member_removed',
+                'data' => ['user_id' => $subscription->data('user_id')],
+                'channel' => $this->name(),
+            ],
+            $connection
+        );
     }
 
     /**
@@ -78,5 +88,17 @@ trait InteractsWithPresenceChannels
                 'hash' => $connections->keyBy('user_id')->map->user_info->toArray(),
             ],
         ];
+    }
+
+    /**
+     * Determine if the given user is subscribed to the channel.
+     */
+    protected function userIsSubscribed(?string $userId): bool
+    {
+        if (! $userId) {
+            return false;
+        }
+
+        return collect($this->connections->all())->map(fn ($connection) => (string) $connection->data('user_id'))->contains($userId);
     }
 }

--- a/tests/Feature/Protocols/Pusher/Reverb/ServerTest.php
+++ b/tests/Feature/Protocols/Pusher/Reverb/ServerTest.php
@@ -470,3 +470,15 @@ it('buffers large requests correctly', function () {
     expect($response->getStatusCode())->toBe(200);
     expect($response->getBody()->getContents())->toBe('{}');
 });
+
+it('subscription_succeeded event contains unique list of users', function () {
+    $data = ['user_id' => 1, 'user_info' => ['name' => 'Test User']];
+    subscribe('presence-test-channel', data: $data);
+    $data = ['user_id' => 1, 'user_info' => ['name' => 'Test User']];
+    $response = subscribe('presence-test-channel', data: $data);
+
+    expect($response)->toContain('pusher_internal:subscription_succeeded');
+    expect($response)->toContain('"count\":1');
+    expect($response)->toContain('"ids\":[1]');
+    expect($response)->toContain('"hash\":{\"1\":{\"name\":\"Test User\"}}');
+});


### PR DESCRIPTION
This PR resolves #213 

The fixes introduced all occur when a user is logged in to a single account, but connected to Reverb in multiple tabs or browswers.

The `subscription_succeeded` event should contain a unique list of connected user IDs.

The `member_added` event should only be dispatched the first time a user connects to the channel (e.g. the first browser tab).

The `member_removed` event should only be dispatched when the user no longer has any connections remaining (e.g. closed all tabs).

Details can be found in the [Pusher spec](https://pusher.com/docs/channels/using_channels/presence-channels/#pushermember_added-1661816671).