### PR TITLE
Options are not necessary at Application level

### DIFF
--- a/config/reverb.php
+++ b/config/reverb.php
@@ -74,12 +74,6 @@ return [
                 'key' => env('REVERB_APP_KEY'),
                 'secret' => env('REVERB_APP_SECRET'),
                 'app_id' => env('REVERB_APP_ID'),
-                'options' => [
-                    'host' => env('REVERB_HOST'),
-                    'port' => env('REVERB_PORT', 443),
-                    'scheme' => env('REVERB_SCHEME', 'https'),
-                    'useTLS' => env('REVERB_SCHEME', 'https') === 'https',
-                ],
                 'allowed_origins' => ['*'],
                 'ping_interval' => env('REVERB_APP_PING_INTERVAL', 60),
                 'max_message_size' => env('REVERB_APP_MAX_MESSAGE_SIZE', 10_000),

--- a/src/Application.php
+++ b/src/Application.php
@@ -13,8 +13,7 @@ class Application
         protected string $secret,
         protected int $pingInterval,
         protected array $allowedOrigins,
-        protected int $maxMessageSize,
-        protected array $options = [],
+        protected int $maxMessageSize
     ) {
         //
     }
@@ -70,14 +69,6 @@ class Application
     }
 
     /**
-     * Get the application options.
-     */
-    public function options(): ?array
-    {
-        return $this->options;
-    }
-
-    /**
      * Convert the application to an array.
      *
      * @return array<string, mixed>
@@ -91,7 +82,6 @@ class Application
             'ping_interval' => $this->pingInterval,
             'allowed_origins' => $this->allowedOrigins,
             'max_message_size' => $this->maxMessageSize,
-            'options' => $this->options,
         ];
     }
 }

--- a/src/ConfigApplicationProvider.php
+++ b/src/ConfigApplicationProvider.php
@@ -68,7 +68,6 @@ class ConfigApplicationProvider implements ApplicationProvider
             $app['ping_interval'],
             $app['allowed_origins'],
             $app['max_message_size'],
-            $app['options'] ?? [],
         );
     }
 }

--- a/tests/Unit/ProviderTest.php
+++ b/tests/Unit/ProviderTest.php
@@ -25,11 +25,5 @@ it('retrieves applications from custom provider', function () {
             'ping_interval' => 60,
             'allowed_origins' => ['*'],
             'max_message_size' => 10_000,
-            'options' => [
-                'host' => 'localhost',
-                'port' => 443,
-                'scheme' => 'https',
-                'useTLS' => true,
-            ],
         ]);
 });


### PR DESCRIPTION
Options like `HOST` `PORT` are only useful at server level, config them at app level makes no sense and won't work, so remove them from the default config file to avoid confusion.