### PR TITLE
[1.x] Add support for wildcard allowed origins

### DIFF
--- a/src/Protocols/Pusher/Server.php
+++ b/src/Protocols/Pusher/Server.php
@@ -125,8 +125,12 @@ class Server
 
         $origin = parse_url($connection->origin(), PHP_URL_HOST);
 
-        if (! $origin || ! in_array($origin, $allowedOrigins)) {
-            throw new InvalidOrigin;
+        foreach ($allowedOrigins as $allowedOrigin) {
+            if (Str::is($allowedOrigin, $origin)) {
+                return;
+            }
         }
+
+        throw new InvalidOrigin;
     }
 }

--- a/tests/FakeConnection.php
+++ b/tests/FakeConnection.php
@@ -25,11 +25,6 @@ class FakeConnection extends BaseConnection
     public string $identifier = '19c1c8e8-351b-4eb5-b6d9-6cbfc54a3446';
 
     /**
-     * Connection origin.
-     */
-    public ?string $origin = 'http://localhost';
-
-    /**
      * Connection socket ID.
      *
      * @var string
@@ -45,9 +40,7 @@ class FakeConnection extends BaseConnection
             $this->identifier = $identifier;
         }
 
-        if ($origin) {
-            $this->origin = $origin;
-        }
+        $this->origin = $origin ?? 'http://localhost';
     }
 
     /**
@@ -81,10 +74,10 @@ class FakeConnection extends BaseConnection
     /**
      * Get the origin of the connection.
      */
-    public function origin(): string
-    {
-        return $this->origin;
-    }
+//    public function origin(): string
+//    {
+//        return $this->origin;
+//    }
 
     /**
      * Set the connection last seen at timestamp.

--- a/tests/FakeConnection.php
+++ b/tests/FakeConnection.php
@@ -25,6 +25,11 @@ class FakeConnection extends BaseConnection
     public string $identifier = '19c1c8e8-351b-4eb5-b6d9-6cbfc54a3446';
 
     /**
+     * Connection origin.
+     */
+    public ?string $origin = 'http://localhost';
+
+    /**
      * Connection socket ID.
      *
      * @var string
@@ -34,10 +39,14 @@ class FakeConnection extends BaseConnection
     /**
      * Create a new fake connection instance.
      */
-    public function __construct(?string $identifier = null)
+    public function __construct(?string $identifier = null, ?string $origin = null)
     {
         if ($identifier) {
             $this->identifier = $identifier;
+        }
+
+        if ($origin) {
+            $this->origin = $origin;
         }
     }
 
@@ -74,7 +83,7 @@ class FakeConnection extends BaseConnection
      */
     public function origin(): string
     {
-        return 'http://localhost';
+        return $this->origin;
     }
 
     /**

--- a/tests/FakeConnection.php
+++ b/tests/FakeConnection.php
@@ -72,14 +72,6 @@ class FakeConnection extends BaseConnection
     }
 
     /**
-     * Get the origin of the connection.
-     */
-//    public function origin(): string
-//    {
-//        return $this->origin;
-//    }
-
-    /**
      * Set the connection last seen at timestamp.
      */
     public function setLastSeenAt(int $time): FakeConnection

--- a/tests/Unit/Protocols/Pusher/ServerTest.php
+++ b/tests/Unit/Protocols/Pusher/ServerTest.php
@@ -282,9 +282,9 @@ it('unsubscribes a user from a presence channel on disconnection', function () {
         ->with($connection);
 });
 
-it('it rejects a connection from an invalid origin', function () {
-    $this->app['config']->set('reverb.apps.apps.0.allowed_origins', ['laravel.com']);
-    $this->server->open($connection = new FakeConnection);
+it('it rejects a connection from an invalid origin', function (string $origin, array $allowedOrigins) {
+    $this->app['config']->set('reverb.apps.apps.0.allowed_origins', $allowedOrigins);
+    $this->server->open($connection = new FakeConnection(origin: $origin));
 
     $connection->assertReceived([
         'event' => 'pusher:error',
@@ -293,11 +293,24 @@ it('it rejects a connection from an invalid origin', function () {
             'message' => 'Origin not allowed',
         ]),
     ]);
-});
+})->with([
+    'localhost' => [
+        'http://localhost',
+        ['laravel.com'],
+    ],
+    'subdomain' => [
+        'http://sub.laravel.com',
+        ['laravel.com'],
+    ],
+    'wildcard' => [
+        'http://laravel.com',
+        ['*.laravel.com'],
+    ]
+]);
 
-it('accepts a connection from an valid origin', function () {
-    $this->app['config']->set('reverb.apps.0.allowed_origins', ['localhost']);
-    $this->server->open($connection = new FakeConnection);
+it('accepts a connection from an valid origin', function (string $origin, array $allowedOrigins) {
+    $this->app['config']->set('reverb.apps.apps.0.allowed_origins', $allowedOrigins);
+    $this->server->open($connection = new FakeConnection(origin: $origin));
 
     $connection->assertReceived([
         'event' => 'pusher:connection_established',
@@ -306,4 +319,13 @@ it('accepts a connection from an valid origin', function () {
             'activity_timeout' => 30,
         ]),
     ]);
-});
+})->with([
+    'localhost' => [
+        'http://localhost',
+        ['localhost'],
+    ],
+    'wildcard' => [
+        'http://sub.localhost',
+        ['localhost', '*.localhost'],
+    ],
+]);

--- a/tests/Unit/Protocols/Pusher/ServerTest.php
+++ b/tests/Unit/Protocols/Pusher/ServerTest.php
@@ -305,7 +305,7 @@ it('it rejects a connection from an invalid origin', function (string $origin, a
     'wildcard' => [
         'http://laravel.com',
         ['*.laravel.com'],
-    ]
+    ],
 ]);
 
 it('accepts a connection from an valid origin', function (string $origin, array $allowedOrigins) {


### PR DESCRIPTION
At present the allowed origins option does not allow for wildcard origins other than `['*']`. As such, if you want to support a set of subdomains as well as the primary domain, you have to list out each one individually into the `reverb.php` config file, e.g.,:

```php
...
'allowed_origins' => ['laravel.com', 'www.laravel.com', 'subdomain.laravel.com'],
...
```

This is all fair and well if the subdomains are well defined, but if you either have a lot of them or your application allows the users to define a subdomain e.g., in the context of a multi-tenant setup, then you may not be able to define these easily.

However, the only wildcard support available is the `['*']` option, but this opens it to all origins, which may not be desired.

This pull request would provide support for wildcard origins to be specified in the config, allowing users to set what origins are allowed, with some more flexibility e.g.:

```php
...
'allowed_origins' => ['laravel.com', '*.laravel.com'],
...
```

With this config, reverb would allow an origin at the root domain level and any subdomain of the root domain.

The underlying change follows a similar pattern/implementation as the CORS middleware, i.e., `Str::is()`

The tests have been extended to include additional checks when wildcard origins are used. I had to extend the `FakeConnection::class` to allow for an origin to be defined besides localhost. I've added this as a 2nd parameter and in the extended tests used the name parameter.

N.B., the test _'accepts a connection from an valid origin'_ has an incorrect config set path for allowed origins, it just happens that the default (`['*']`) allows everything and as such the test passes.