### PR TITLE
Prevent message with data: "" taking server down

### DIFF
--- a/src/Protocols/Pusher/Server.php
+++ b/src/Protocols/Pusher/Server.php
@@ -56,7 +56,7 @@ class Server
                 true => $this->handler->handle(
                     $from,
                     $event['event'],
-                    $event['data'] ?? [],
+                    empty($event['data']) ? [] : $event['data'],
                     $event['channel'] ?? null
                 ),
                 default => ClientEvent::handle($from, $event)


### PR DESCRIPTION
A message like:
```
   1▕ { 
   2▕     "event": "pusher:ping", 
   3▕     "data": "" 
   4▕ } 
```
results in `TypeError`:
```
  Laravel\Reverb\Protocols\Pusher\EventHandler::handle(): Argument #3 ($payload) must be of type array, string given, called in /var/www/html/api/vendor/laravel/reverb/src/Protocols/Pusher/Server.php on line 56
```
which takes the server down.
This fixes it.
