### PR TITLE
Dispatch events when channel subscriptions are created and destroyed.

### DIFF
--- a/src/Events/SubscribedToChannel.php
+++ b/src/Events/SubscribedToChannel.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Laravel\Reverb\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Laravel\Reverb\Contracts\Connection;
+
+class SubscribedToChannel
+{
+    use Dispatchable;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(public Connection $connection, string $channel)
+    {
+        //
+    }
+}

--- a/src/Events/UnsubscribedFromChannel.php
+++ b/src/Events/UnsubscribedFromChannel.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Laravel\Reverb\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Laravel\Reverb\Contracts\Connection;
+
+class UnsubscribedFromChannel
+{
+    use Dispatchable;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(public Connection $connection, string $channel)
+    {
+        //
+    }
+}


### PR DESCRIPTION
This PR adds two events:
1. User subscribing to channel
2. User unsubscribing from channel