### PR TITLE
Dispatch an event when channel created or removed.

### DIFF
--- a/src/Events/ChannelCreated.php
+++ b/src/Events/ChannelCreated.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Laravel\Reverb\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Laravel\Reverb\Protocols\Pusher\Channels\Channel;
+
+class ChannelCreated
+{
+    use Dispatchable;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(public Channel $channel)
+    {
+        //
+    }
+}

--- a/src/Events/ChannelRemoved.php
+++ b/src/Events/ChannelRemoved.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Laravel\Reverb\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Laravel\Reverb\Protocols\Pusher\Channels\Channel;
+
+class ChannelRemoved
+{
+    use Dispatchable;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(public Channel $channel)
+    {
+        //
+    }
+}

--- a/src/Protocols/Pusher/Managers/ArrayChannelManager.php
+++ b/src/Protocols/Pusher/Managers/ArrayChannelManager.php
@@ -7,6 +7,8 @@ use Laravel\Reverb\Application;
 use Laravel\Reverb\Concerns\InteractsWithApplications;
 use Laravel\Reverb\Contracts\ApplicationProvider;
 use Laravel\Reverb\Contracts\Connection;
+use Laravel\Reverb\Events\ChannelCreated;
+use Laravel\Reverb\Events\ChannelRemoved;
 use Laravel\Reverb\Protocols\Pusher\Channels\Channel;
 use Laravel\Reverb\Protocols\Pusher\Channels\ChannelBroker;
 use Laravel\Reverb\Protocols\Pusher\Contracts\ChannelManager as ChannelManagerInterface;
@@ -76,6 +78,8 @@ class ArrayChannelManager implements ChannelManagerInterface
 
         $this->applications[$this->application->id()][$channel->name()] = $channel;
 
+        ChannelCreated::dispatch($channel);
+
         return $channel;
     }
 
@@ -109,6 +113,8 @@ class ArrayChannelManager implements ChannelManagerInterface
     public function remove(Channel $channel): void
     {
         unset($this->applications[$this->application->id()][$channel->name()]);
+
+        ChannelRemoved::dispatch($channel);
     }
 
     /**


### PR DESCRIPTION
When channel is going to be created or removed an event will be triggered, this may be useful when subscriptions are managed by https://github.com/nuwave/lighthouse and channel should be removed from cache when user leaves (removed) form it