### PR TITLE
[1.x] Supports `laravel/prompts` v0.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "illuminate/contracts": "^10.47|^11.0",
         "illuminate/http": "^10.47|^11.0",
         "illuminate/support": "^10.47|^11.0",
-        "laravel/prompts": "^0.1.15",
+        "laravel/prompts": "^0.1.15|^0.2.0",
         "pusher/pusher-php-server": "^7.2",
         "ratchet/rfc6455": "^0.3.1",
         "react/promise-timer": "^1.10",


### PR DESCRIPTION
Laravel Prompts 0.2.0 was released last week: https://github.com/laravel/prompts/releases/tag/v0.2.0
