### PR TITLE
Re-subscribe to the scaling channel when the underlying connection is lost

### DIFF
--- a/src/Servers/Reverb/Publishing/RedisPubSubProvider.php
+++ b/src/Servers/Reverb/Publishing/RedisPubSubProvider.php
@@ -56,6 +56,12 @@ class RedisPubSubProvider implements PubSubProvider
         $this->subscribingClient->on('message', function (string $channel, string $payload) {
             $this->messageHandler->handle($payload);
         });
+
+        $this->subscribingClient->on('unsubscribe', function (string $channel) {
+            if($this->channel === $channel){
+                $this->subscribingClient->subscribe($channel);
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
In scaling mode, when the subscribingClient connection is lost while the app is running, the main app continues to operate without any errors or logs. However, it loses the ability to listen for events on the scaling channel.

According to the [clue/reactphp-redis](https://github.com/clue/reactphp-redis/tree/2.x):

> When using the [createLazyClient()](https://github.com/clue/reactphp-redis/tree/2.x#createlazyclient) method, the unsubscribe and punsubscribe events will be invoked automatically when the underlying connection is lost. This gives you control over re-subscribing to the channels and patterns as appropriate.

So, we need to re-subscribe to the channel when the unsubscribe event is detected.