### PR TITLE
[1.x] Optionally uses control frames for handling ping and pong

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -5,6 +5,7 @@ namespace Laravel\Reverb;
 use Laravel\Reverb\Concerns\GeneratesIdentifiers;
 use Laravel\Reverb\Contracts\Connection as ConnectionContract;
 use Laravel\Reverb\Events\MessageSent;
+use Ratchet\RFC6455\Messaging\Frame;
 
 class Connection extends ConnectionContract
 {
@@ -48,6 +49,14 @@ class Connection extends ConnectionContract
         $this->connection->send($message);
 
         MessageSent::dispatch($this, $message);
+    }
+
+    /**
+     * Send a control frame to the connection.
+     */
+    public function control(string $type = Frame::OP_PING): void
+    {
+        $this->connection->send(new Frame('', opcode: $type));
     }
 
     /**

--- a/src/Contracts/Connection.php
+++ b/src/Contracts/Connection.php
@@ -18,7 +18,7 @@ abstract class Connection
     protected $hasBeenPinged = false;
 
     /**
-     * Uses control frames.
+     * Indicates if the connection uses control frames.
      */
     protected $usesControlFrames = false;
 

--- a/src/Contracts/Connection.php
+++ b/src/Contracts/Connection.php
@@ -3,6 +3,7 @@
 namespace Laravel\Reverb\Contracts;
 
 use Laravel\Reverb\Application;
+use Ratchet\RFC6455\Messaging\Frame;
 
 abstract class Connection
 {
@@ -15,6 +16,11 @@ abstract class Connection
      * Stores the ping state of the connection.
      */
     protected $hasBeenPinged = false;
+
+    /**
+     * Uses control frames.
+     */
+    protected $usesControlFrames = false;
 
     /**
      * Create a new connection instance.
@@ -38,6 +44,11 @@ abstract class Connection
      * Send a message to the connection.
      */
     abstract public function send(string $message): void;
+
+    /**
+     * Send a control frame to the connection.
+     */
+    abstract public function control(string $type = Frame::OP_PING): void;
 
     /**
      * Terminate a connection.
@@ -135,5 +146,23 @@ abstract class Connection
     public function isStale(): bool
     {
         return $this->isInactive() && $this->hasBeenPinged;
+    }
+
+    /**
+     * Mark the connection as using control frames to track activity.
+     */
+    public function setUsesControlFrames(bool $usesControlFrames = true): Connection
+    {
+        $this->usesControlFrames = $usesControlFrames;
+
+        return $this;
+    }
+
+    /**
+     * Determine whether the connection uses control frames.
+     */
+    public function usesControlFrames(): bool
+    {
+        return $this->usesControlFrames;
     }
 }

--- a/src/Contracts/Connection.php
+++ b/src/Contracts/Connection.php
@@ -149,6 +149,14 @@ abstract class Connection
     }
 
     /**
+     * Determine whether the connection uses control frames.
+     */
+    public function usesControlFrames(): bool
+    {
+        return $this->usesControlFrames;
+    }
+
+    /**
      * Mark the connection as using control frames to track activity.
      */
     public function setUsesControlFrames(bool $usesControlFrames = true): Connection
@@ -156,13 +164,5 @@ abstract class Connection
         $this->usesControlFrames = $usesControlFrames;
 
         return $this;
-    }
-
-    /**
-     * Determine whether the connection uses control frames.
-     */
-    public function usesControlFrames(): bool
-    {
-        return $this->usesControlFrames;
     }
 }

--- a/src/Protocols/Pusher/EventHandler.php
+++ b/src/Protocols/Pusher/EventHandler.php
@@ -117,9 +117,9 @@ class EventHandler
      */
     public function ping(Connection $connection): void
     {
-        $connection->usesControlFrames() ?
-            $connection->control() :
-            static::send($connection, 'ping');
+        $connection->usesControlFrames() 
+            ? $connection->control() 
+            : static::send($connection, 'ping');
 
         $connection->ping();
     }

--- a/src/Protocols/Pusher/EventHandler.php
+++ b/src/Protocols/Pusher/EventHandler.php
@@ -117,7 +117,9 @@ class EventHandler
      */
     public function ping(Connection $connection): void
     {
-        static::send($connection, 'ping');
+        $connection->usesControlFrames() ?
+            $connection->control() :
+            static::send($connection, 'ping');
 
         $connection->ping();
     }

--- a/src/Protocols/Pusher/Http/Controllers/PusherController.php
+++ b/src/Protocols/Pusher/Http/Controllers/PusherController.php
@@ -8,6 +8,7 @@ use Laravel\Reverb\Exceptions\InvalidApplication;
 use Laravel\Reverb\Protocols\Pusher\Server as PusherServer;
 use Laravel\Reverb\Servers\Reverb\Connection;
 use Psr\Http\Message\RequestInterface;
+use Ratchet\RFC6455\Messaging\FrameInterface;
 
 class PusherController
 {
@@ -32,6 +33,10 @@ class PusherController
 
         $connection->onMessage(
             fn ($message) => $this->server->message($reverbConnection, (string) $message)
+        );
+
+        $connection->onControl(
+            fn (FrameInterface $message) => $this->server->control($reverbConnection, $message)
         );
 
         $connection->onClose(

--- a/src/Protocols/Pusher/Server.php
+++ b/src/Protocols/Pusher/Server.php
@@ -10,6 +10,8 @@ use Laravel\Reverb\Loggers\Log;
 use Laravel\Reverb\Protocols\Pusher\Contracts\ChannelManager;
 use Laravel\Reverb\Protocols\Pusher\Exceptions\InvalidOrigin;
 use Laravel\Reverb\Protocols\Pusher\Exceptions\PusherException;
+use Ratchet\RFC6455\Messaging\Frame;
+use Ratchet\RFC6455\Messaging\FrameInterface;
 
 class Server
 {
@@ -67,6 +69,17 @@ class Server
             MessageReceived::dispatch($from, $message);
         } catch (Exception $e) {
             $this->error($from, $e);
+        }
+    }
+
+    public function control(Connection $from, FrameInterface $message): void
+    {
+        Log::info('Control Frame Received', $from->id());
+        Log::message($message);
+
+        
+        if ($message->getOpcode() === Frame::OP_PING) {
+            $from->touch();
         }
     }
 

--- a/src/Protocols/Pusher/Server.php
+++ b/src/Protocols/Pusher/Server.php
@@ -76,7 +76,6 @@ class Server
     {
         Log::info('Control Frame Received', $from->id());
         Log::message($message);
-
         
         if ($message->getOpcode() === Frame::OP_PING) {
             $from->touch();

--- a/src/Protocols/Pusher/Server.php
+++ b/src/Protocols/Pusher/Server.php
@@ -72,11 +72,16 @@ class Server
         }
     }
 
+    /**
+     * Handle a low-level WebSocket control frame.
+     */
     public function control(Connection $from, FrameInterface $message): void
     {
         Log::info('Control Frame Received', $from->id());
         Log::message($message);
-        
+
+        $from->setUsesControlFrames();
+
         if ($message->getOpcode() === Frame::OP_PING) {
             $from->touch();
         }

--- a/src/Protocols/Pusher/Server.php
+++ b/src/Protocols/Pusher/Server.php
@@ -82,7 +82,7 @@ class Server
 
         $from->setUsesControlFrames();
 
-        if ($message->getOpcode() === Frame::OP_PING) {
+        if (in_array($message->getOpcode(), [Frame::OP_PING, Frame::OP_PONG], strict: true)) {
             $from->touch();
         }
     }

--- a/src/Servers/Reverb/Connection.php
+++ b/src/Servers/Reverb/Connection.php
@@ -28,6 +28,13 @@ class Connection extends EventEmitter implements WebSocketConnection
     protected $onMessage;
 
     /**
+     * The control frame handler.
+     *
+     * @var ?callable
+     */
+    protected $onControl;
+
+    /**
      * The connection close handler.
      *
      * @var ?callable
@@ -83,6 +90,10 @@ class Connection extends EventEmitter implements WebSocketConnection
      */
     public function control(FrameInterface $message): void
     {
+        if ($this->onControl) {
+            ($this->onControl)($message);
+        }
+
         match ($message->getOpcode()) {
             Frame::OP_PING => $this->send(new Frame($message->getPayload(), opcode: Frame::OP_PONG)),
             Frame::OP_PONG => fn () => null,
@@ -96,6 +107,14 @@ class Connection extends EventEmitter implements WebSocketConnection
     public function onMessage(callable $callback): void
     {
         $this->onMessage = $callback;
+    }
+
+    /**
+     * Set the control frame handler.
+     */
+    public function onControl(callable $callback): void
+    {
+        $this->onControl = $callback;
     }
 
     /**

--- a/tests/FakeConnection.php
+++ b/tests/FakeConnection.php
@@ -7,6 +7,7 @@ use Laravel\Reverb\Application;
 use Laravel\Reverb\Concerns\GeneratesIdentifiers;
 use Laravel\Reverb\Contracts\ApplicationProvider;
 use Laravel\Reverb\Contracts\Connection as BaseConnection;
+use Ratchet\RFC6455\Messaging\Frame;
 
 class FakeConnection extends BaseConnection
 {
@@ -96,6 +97,12 @@ class FakeConnection extends BaseConnection
     {
         $this->messages[] = $message;
     }
+
+    /**
+     * Send a control frame to the connection.
+     */
+    public function control(string $type = Frame::OP_PING): void { }
+
 
     /**
      * Terminate a connection.

--- a/tests/Feature/Protocols/Pusher/Reverb/ServerTest.php
+++ b/tests/Feature/Protocols/Pusher/Reverb/ServerTest.php
@@ -4,6 +4,7 @@ use Illuminate\Support\Arr;
 use Laravel\Reverb\Jobs\PingInactiveConnections;
 use Laravel\Reverb\Jobs\PruneStaleConnections;
 use Laravel\Reverb\Tests\ReverbTestCase;
+use Ratchet\RFC6455\Messaging\Frame;
 use React\Promise\Deferred;
 
 use function Ratchet\Client\connect as wsConnect;
@@ -481,4 +482,11 @@ it('subscription_succeeded event contains unique list of users', function () {
     expect($response)->toContain('"count\":1');
     expect($response)->toContain('"ids\":[1]');
     expect($response)->toContain('"hash\":{\"1\":{\"name\":\"Test User\"}}');
+});
+
+it('can handle a ping control frame', function () {
+    $connection = connect();
+    $connection->send(new Frame('', opcode: Frame::OP_PING));
+
+    $connection->assertReceived('pong');
 });

--- a/tests/Feature/Protocols/Pusher/Reverb/ServerTest.php
+++ b/tests/Feature/Protocols/Pusher/Reverb/ServerTest.php
@@ -486,9 +486,29 @@ it('subscription_succeeded event contains unique list of users', function () {
 
 it('can handle a ping control frame', function () {
     $connection = connect();
+    subscribe('test-channel', connection: $connection);
+    $channels = channels();
+    $managedConnection = Arr::first($channels->connections());
+    $subscribedAt = $managedConnection->lastSeenAt();
+    sleep(1);
     $connection->send(new Frame('', opcode: Frame::OP_PING));
-
+    
     $connection->assertPonged();
+    expect($managedConnection->lastSeenAt())->toBeGreaterThan($subscribedAt);
+});
+
+it('can handle a pong control frame', function () {
+    $connection = connect();
+    subscribe('test-channel', connection: $connection);
+    $channels = channels();
+    $managedConnection = Arr::first($channels->connections());
+    $subscribedAt = $managedConnection->lastSeenAt();
+    sleep(1);
+    $connection->send(new Frame('', opcode: Frame::OP_PONG));
+    
+    $connection->assertNotPinged();
+    $connection->assertNotPonged();
+    expect($managedConnection->lastSeenAt())->toBeGreaterThan($subscribedAt);
 });
 
 it('uses pusher control messages by default', function () {

--- a/tests/Feature/Protocols/Pusher/Reverb/ServerTest.php
+++ b/tests/Feature/Protocols/Pusher/Reverb/ServerTest.php
@@ -488,5 +488,5 @@ it('can handle a ping control frame', function () {
     $connection = connect();
     $connection->send(new Frame('', opcode: Frame::OP_PING));
 
-    $connection->assertReceived('pong');
+    $connection->assertPonged();
 });

--- a/tests/TestConnection.php
+++ b/tests/TestConnection.php
@@ -25,6 +25,10 @@ class TestConnection
      */
     public $receivedMessages = [];
 
+    public $wasPinged = false;
+
+    public $wasPonged = false;
+
     /**
      * Create a new test connection instance.
      */
@@ -32,6 +36,14 @@ class TestConnection
     {
         $connection->on('message', function ($message) {
             $this->receivedMessages[] = (string) $message;
+        });
+
+        $connection->on('ping', function () {
+            $this->wasPinged = true;
+        });
+
+        $connection->on('pong', function () {
+            $this->wasPonged = true;
         });
 
         $connection->on('close', function ($code, $message) {
@@ -76,7 +88,6 @@ class TestConnection
      */
     public function assertReceived(string $message, ?int $count = null): void
     {
-        dump($this->receivedMessages);
         if (! in_array($message, $this->receivedMessages) || $count !== null) {
             $this->await();
         }
@@ -88,6 +99,26 @@ class TestConnection
         }
 
         expect($this->receivedMessages)->toContain($message);
+    }
+
+    /**
+     * Assert the connection was pinged during the test.
+     */
+    public function assertPinged(): void
+    {
+        $this->await();
+
+        expect($this->wasPinged)->toBeTrue();
+    }
+
+    /**
+     * Assert the connection was ponged during the test.
+     */
+    public function assertPonged(): void
+    {
+        $this->await();
+
+        expect($this->wasPonged)->toBeTrue();
     }
 
     /**

--- a/tests/TestConnection.php
+++ b/tests/TestConnection.php
@@ -102,6 +102,18 @@ class TestConnection
     }
 
     /**
+     * Assert that the connection did not receiv the given message.
+     */
+    public function assertNotReceived(string $message): void
+    {
+        if (! in_array($message, $this->receivedMessages)) {
+            $this->await();
+        }
+
+        expect($this->receivedMessages)->not->toContain($message);
+    }
+
+    /**
      * Assert the connection was pinged during the test.
      */
     public function assertPinged(): void
@@ -112,6 +124,16 @@ class TestConnection
     }
 
     /**
+     * Assert the connection was not pinged during the test.
+     */
+    public function assertNotPinged(): void
+    {
+        $this->await();
+
+        expect($this->wasPinged)->toBeFalse();
+    }
+
+    /**
      * Assert the connection was ponged during the test.
      */
     public function assertPonged(): void
@@ -119,6 +141,16 @@ class TestConnection
         $this->await();
 
         expect($this->wasPonged)->toBeTrue();
+    }
+
+    /**
+     * Assert the connection was not ponged during the test.
+     */
+    public function assertNotPonged(): void
+    {
+        $this->await();
+
+        expect($this->wasPonged)->toBeFalse();
     }
 
     /**

--- a/tests/TestConnection.php
+++ b/tests/TestConnection.php
@@ -76,6 +76,7 @@ class TestConnection
      */
     public function assertReceived(string $message, ?int $count = null): void
     {
+        dump($this->receivedMessages);
         if (! in_array($message, $this->receivedMessages) || $count !== null) {
             $this->await();
         }


### PR DESCRIPTION
This PR attempts to resolve #224 

It's been reported that some of the Pusher clients don't support the `pusher:ping|pong` event format for handling pings and pongs and will, instead, rely on the low-level ping/pong control frames provided by the WebSocket specification.

This PR aims to address that by:

- Defaulting to Pusher's `pusher:ping|pong`
- Updating the last active timestamp on the connection when receiving a low-level `ping` control frame. The aim here is to prevent connections getting pruned by the `PruneStaleConnections` job
- Set a boolean status on the connection of `usesControlFrames` when receiving a low-level `ping` control frame and, when this value is `true`, send low-level `ping` control frames when running the `PingInactiveConnections` job.
