### PR TITLE
Enable serialization of the connection

### DIFF
--- a/src/Concerns/SerializesConnections.php
+++ b/src/Concerns/SerializesConnections.php
@@ -15,7 +15,6 @@ trait SerializesConnections
     {
         return [
             'id' => $this->id(),
-            'identifier' => $this->identifier(),
             'application' => $this->app()->id(),
             'origin' => $this->origin(),
             'lastSeenAt' => $this->lastSeenAt,
@@ -29,7 +28,6 @@ trait SerializesConnections
     public function __unserialize(array $values): void
     {
         $this->id = $values['id'];
-        $this->identifier = $values['identifier'];
         $this->application = app(ApplicationProvider::class)->findById($values['application']);
         $this->origin = $values['origin'];
         $this->lastSeenAt = $values['lastSeenAt'] ?? null;

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -3,13 +3,14 @@
 namespace Laravel\Reverb;
 
 use Laravel\Reverb\Concerns\GeneratesIdentifiers;
+use Laravel\Reverb\Concerns\SerializesConnections;
 use Laravel\Reverb\Contracts\Connection as ConnectionContract;
 use Laravel\Reverb\Events\MessageSent;
 use Ratchet\RFC6455\Messaging\Frame;
 
 class Connection extends ConnectionContract
 {
-    use GeneratesIdentifiers;
+    use GeneratesIdentifiers, SerializesConnections;
 
     /**
      * The normalized socket ID.


### PR DESCRIPTION

Adds the `SerializesConnections` trait to the `Connection` class, enabling its serialization. 

It is sometimes necessary to serialize the connection, as it is dispatched in common events such as `MessageSent` which may need storage. Listeners may wish to automatically queue the handling of such events by implementing `ShouldQueue`. This currently results in a "serialization of 'closure' is not allowed" error, as the connection object passed in the event is not serializable.

A workaround is to manually create the queue job in the listener's handler, by first parsing the connection object. However this sometimes isn't ideal and adds complexity.

In the context of Reverb, I think it's particularly important the handling of events are easily queued to prevent blocking of the event loop.