### PR TITLE
Proposed Fix to [BUG] Reverb Broadcast Stop If Redis Connection Lost

### DIFF
--- a/src/Servers/Reverb/Http/Server.php
+++ b/src/Servers/Reverb/Http/Server.php
@@ -14,6 +14,8 @@ use React\Socket\ServerInterface;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Throwable;
 
+use function React\Promise\set_rejection_handler;
+
 class Server
 {
     use ClosesConnections;
@@ -38,6 +40,17 @@ class Server
      */
     public function start(): void
     {
+        /** Set global promise rejection handler */
+        set_rejection_handler(function (Throwable $e) {
+            Log::error($e->getMessage());
+
+            /** Echo error message */
+            echo "Unhandled exception: {$e->getMessage()}\n Server will stop.\n";
+
+            /** Stop the server */
+            $this->stop();
+        });
+
         $this->loop->run();
     }
 


### PR DESCRIPTION
After reviewing the trace and exception.
I found that it's an unhandled rejection of promise.

I propose to catch this globally and then stop the server.
This will help docker or any watchdog system to restart the reverb service.

But I'm also thinking if is it better to send restart signal?
Let me know what's your opinion?

The goal of this PR is to fix #258 
Closes #258 on merge.