### PR TITLE
[1.x] Allow publishing to others only when using Redis

### DIFF
--- a/src/Protocols/Pusher/EventDispatcher.php
+++ b/src/Protocols/Pusher/EventDispatcher.php
@@ -28,6 +28,7 @@ class EventDispatcher
             'type' => 'message',
             'application' => serialize($app),
             'payload' => $payload,
+            'socket_id' => $connection?->id(),
         ]);
     }
 
@@ -46,7 +47,6 @@ class EventDispatcher
             }
 
             $payload['channel'] = $channel->name();
-
             $channel->broadcast($payload, $connection);
         }
     }

--- a/src/Protocols/Pusher/EventDispatcher.php
+++ b/src/Protocols/Pusher/EventDispatcher.php
@@ -47,6 +47,7 @@ class EventDispatcher
             }
 
             $payload['channel'] = $channel->name();
+
             $channel->broadcast($payload, $connection);
         }
     }

--- a/src/Protocols/Pusher/PusherPubSubIncomingMessageHandler.php
+++ b/src/Protocols/Pusher/PusherPubSubIncomingMessageHandler.php
@@ -16,10 +16,15 @@ class PusherPubSubIncomingMessageHandler implements PubSubIncomingMessageHandler
 
         $application = unserialize($event['application']);
 
+        $except = isset($event['socket_id']) ?
+            app(ChannelManager::class)->for($application)->connections()[$event['socket_id']] ?? null
+            : null;
+
         match ($event['type'] ?? null) {
             'message' => EventDispatcher::dispatchSynchronously(
                 $application,
-                $event['payload']
+                $event['payload'],
+                $except?->connection()
             ),
             'metrics' => app(MetricsHandler::class)->publish(
                 $application,

--- a/src/Protocols/Pusher/PusherPubSubIncomingMessageHandler.php
+++ b/src/Protocols/Pusher/PusherPubSubIncomingMessageHandler.php
@@ -15,6 +15,7 @@ class PusherPubSubIncomingMessageHandler implements PubSubIncomingMessageHandler
         $event = json_decode($payload, associative: true, flags: JSON_THROW_ON_ERROR);
 
         $application = unserialize($event['application']);
+
         $except = isset($event['socket_id']) ?
             app(ChannelManager::class)->for($application)->connections()[$event['socket_id']] ?? null
             : null;

--- a/src/Protocols/Pusher/PusherPubSubIncomingMessageHandler.php
+++ b/src/Protocols/Pusher/PusherPubSubIncomingMessageHandler.php
@@ -15,10 +15,7 @@ class PusherPubSubIncomingMessageHandler implements PubSubIncomingMessageHandler
         $event = json_decode($payload, associative: true, flags: JSON_THROW_ON_ERROR);
 
         $application = unserialize($event['application']);
-
-        $except = isset($event['socket_id']) ?
-            app(ChannelManager::class)->for($application)->connections()[$event['socket_id']] ?? null
-            : null;
+        $except = app(ChannelManager::class)->for($application)->connections()[$event['socket_id']] ?? null;
 
         match ($event['type'] ?? null) {
             'message' => EventDispatcher::dispatchSynchronously(

--- a/src/Protocols/Pusher/PusherPubSubIncomingMessageHandler.php
+++ b/src/Protocols/Pusher/PusherPubSubIncomingMessageHandler.php
@@ -15,7 +15,9 @@ class PusherPubSubIncomingMessageHandler implements PubSubIncomingMessageHandler
         $event = json_decode($payload, associative: true, flags: JSON_THROW_ON_ERROR);
 
         $application = unserialize($event['application']);
-        $except = app(ChannelManager::class)->for($application)->connections()[$event['socket_id']] ?? null;
+        $except = isset($event['socket_id']) ?
+            app(ChannelManager::class)->for($application)->connections()[$event['socket_id']] ?? null
+            : null;
 
         match ($event['type'] ?? null) {
             'message' => EventDispatcher::dispatchSynchronously(

--- a/tests/Unit/EventTest.php
+++ b/tests/Unit/EventTest.php
@@ -11,7 +11,7 @@ it('can publish an event when enabled', function () {
     app(ServerProviderManager::class)->withPublishing();
     $pubSub = Mockery::mock(PubSubProvider::class);
     $pubSub->shouldReceive('publish')->once()
-        ->with(['type' => 'message', 'application' => serialize($app), 'payload' => ['channel' => 'test-channel']]);
+        ->with(['type' => 'message', 'application' => serialize($app), 'payload' => ['channel' => 'test-channel'], 'socket_id' => null]);
 
     $this->app->instance(PubSubProvider::class, $pubSub);
 


### PR DESCRIPTION
Pass SocketID through redis, and filter it on the receiving end.

This ensures that ->toOthers() works with scaling = true

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
