### PR TITLE
Bugfix for PR 275 - omit socket-id if null

### DIFF
--- a/src/Protocols/Pusher/EventDispatcher.php
+++ b/src/Protocols/Pusher/EventDispatcher.php
@@ -24,12 +24,15 @@ class EventDispatcher
             return;
         }
 
-        app(PubSubProvider::class)->publish([
+        $data = [
             'type' => 'message',
             'application' => serialize($app),
             'payload' => $payload,
-            'socket_id' => $connection?->id(),
-        ]);
+        ];
+        if ($connection?->id() !== null) {
+            $data['socket_id'] = $connection?->id();
+        }
+        app(PubSubProvider::class)->publish($data);
     }
 
     /**

--- a/src/Protocols/Pusher/EventDispatcher.php
+++ b/src/Protocols/Pusher/EventDispatcher.php
@@ -29,9 +29,11 @@ class EventDispatcher
             'application' => serialize($app),
             'payload' => $payload,
         ];
+
         if ($connection?->id() !== null) {
             $data['socket_id'] = $connection?->id();
         }
+
         app(PubSubProvider::class)->publish($data);
     }
 


### PR DESCRIPTION
My fix for scaling with redis in PR 275 faails with an exception if a queue worker creates a push message, as the validate_socket() method does not accept null, but activates if the socket_id key is present.

I changed the code, so that the socket_id key is only is only set, if it is non-null.