### PR TITLE
[1.x] Check if channel variable isn't null when passed as a filter on channels() method in ArrayChannelManager

### DIFF
--- a/src/Protocols/Pusher/Managers/ArrayChannelManager.php
+++ b/src/Protocols/Pusher/Managers/ArrayChannelManager.php
@@ -134,7 +134,7 @@ class ArrayChannelManager implements ChannelManagerInterface
     {
         $channels = $this->applications[$this->application->id()] ?? [];
 
-        if ($channel) {
+        if (isset($channel)) {
             return $channels[$channel] ?? null;
         }
 

--- a/tests/Unit/Protocols/Pusher/EventTest.php
+++ b/tests/Unit/Protocols/Pusher/EventTest.php
@@ -38,6 +38,19 @@ it('can subscribe to a channel', function () {
     ]);
 });
 
+it('can subscribe to an empty channel', function () {
+    $this->pusher->handle(
+        $this->connection,
+        'pusher:subscribe',
+        ['channel' => '']
+    );
+
+    $this->connection->assertReceived([
+        'event' => 'pusher_internal:subscription_succeeded',
+        'data' => '{}',
+    ]);
+});
+
 it('can unsubscribe from a channel', function () {
     $this->pusher->handle(
         $this->connection,


### PR DESCRIPTION
Fixes issue https://github.com/laravel/reverb/issues/291