### PR TITLE
Fix incorrect condition in `CliLogger::message()` method

### DIFF
--- a/src/Loggers/CliLogger.php
+++ b/src/Loggers/CliLogger.php
@@ -52,7 +52,7 @@ class CliLogger implements Logger
             $message['data'] = json_decode($message['data'], true);
         }
 
-        if (isset($message['data']['channel_data'])) {
+        if (isset($message['data']['channel_data']) && is_string($message['data'])) {
             $message['data']['channel_data'] = json_decode($message['data']['channel_data'], true);
         }
 


### PR DESCRIPTION
**Expected behavior:**
The `channel_data` should be decoded correctly.

**Proposed fix:**
Replace the condition in the `if` statement with the correct one:
```php
if (isset($message['data']['channel_data']) && is_string($message['data']['channel_data'])) {
    $message['data']['channel_data'] = json_decode($message['data']['channel_data'], true);
}