### PR TITLE
Fix incorrect condition in CliLogger::message method

### DIFF
--- a/src/Loggers/CliLogger.php
+++ b/src/Loggers/CliLogger.php
@@ -52,7 +52,7 @@ class CliLogger implements Logger
             $message['data'] = json_decode($message['data'], true);
         }
 
-        if (isset($message['data']['channel_data'])) {
+        if (isset($message['data']['channel_data']) && is_string($message['data'])) {
             $message['data']['channel_data'] = json_decode($message['data']['channel_data'], true);
         }
 

--- a/src/Protocols/Pusher/Server.php
+++ b/src/Protocols/Pusher/Server.php
@@ -3,6 +3,7 @@
 namespace Laravel\Reverb\Protocols\Pusher;
 
 use Exception;
+use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
 use Laravel\Reverb\Contracts\Connection;
 use Laravel\Reverb\Events\MessageReceived;
@@ -53,6 +54,15 @@ class Server
 
         try {
             $event = json_decode($message, associative: true, flags: JSON_THROW_ON_ERROR);
+
+            $validate = Validator::make($event, [
+                'event' => ['required', 'string'],
+                'data' => ['nullable', 'array'],
+                'channel' => ['nullable', 'string'],
+                'data.channel' => ['required', 'string'],
+                'data.auth' => ['nullable', 'string'],
+                'data.channel_data' => ['nullable', 'json'],
+            ])->validate();
 
             match (Str::startsWith($event['event'], 'pusher:')) {
                 true => $this->handler->handle(

--- a/tests/Unit/Protocols/Pusher/ServerTest.php
+++ b/tests/Unit/Protocols/Pusher/ServerTest.php
@@ -93,6 +93,165 @@ it('sends an error if something fails', function () {
         ]),
     ]);
 });
+it('sends an error if something fails for event type', function () {
+
+    $this->server->message(
+        $connection = new FakeConnection,
+        json_encode([
+            'event' => [],
+        ])
+    );
+
+    $connection->assertReceived([
+        'event' => 'pusher:error',
+        'data' => json_encode([
+            'code' => 4200,
+            'message' => 'Invalid message format',
+        ]),
+    ]);
+});
+
+it('sends an error if something fails for data type', function () {
+
+    $this->server->message(
+        $connection = new FakeConnection,
+        json_encode([
+            'event' => 'pusher:subscribe',
+            'data' => 'sfsfsfs',
+        ])
+    );
+
+    $connection->assertReceived([
+        'event' => 'pusher:error',
+        'data' => json_encode([
+            'code' => 4200,
+            'message' => 'Invalid message format',
+        ]),
+    ]);
+});
+
+it('sends an error if something fails for data channel type', function () {
+
+    $this->server->message(
+        $connection = new FakeConnection,
+        json_encode([
+            'event' => 'pusher:subscribe',
+            'data' => [
+                'channel' => [],
+            ],
+        ])
+    );
+
+    $connection->assertReceived([
+        'event' => 'pusher:error',
+        'data' => json_encode([
+            'code' => 4200,
+            'message' => 'Invalid message format',
+        ]),
+    ]);
+
+    $this->server->message(
+        $connection = new FakeConnection,
+        json_encode([
+            'event' => 'pusher:subscribe',
+            'data' => [
+                'channel' => null,
+            ],
+        ])
+    );
+
+    $connection->assertReceived([
+        'event' => 'pusher:error',
+        'data' => json_encode([
+            'code' => 4200,
+            'message' => 'Invalid message format',
+        ]),
+    ]);
+});
+
+it('sends an error if something fails for data auth type', function () {
+
+    $this->server->message(
+        $connection = new FakeConnection,
+        json_encode([
+            'event' => 'pusher:subscribe',
+            'data' => [
+                'channel' => 'presence-test-channel',
+                'auth' => [],
+            ],
+        ])
+    );
+
+    $connection->assertReceived([
+        'event' => 'pusher:error',
+        'data' => json_encode([
+            'code' => 4200,
+            'message' => 'Invalid message format',
+        ]),
+    ]);
+});
+
+it('sends an error if something fails for data channel_data type', function () {
+
+    $this->server->message(
+        $connection = new FakeConnection,
+        json_encode([
+            'event' => 'pusher:subscribe',
+            'data' => [
+                'channel' => 'presence-test-channel',
+                'auth' => '',
+                'channel_data' => [],
+            ],
+        ])
+    );
+
+    $connection->assertReceived([
+        'event' => 'pusher:error',
+        'data' => json_encode([
+            'code' => 4200,
+            'message' => 'Invalid message format',
+        ]),
+    ]);
+
+    $this->server->message(
+        $connection = new FakeConnection,
+        json_encode([
+            'event' => 'pusher:subscribe',
+            'data' => [
+                'channel' => 'presence-test-channel',
+                'auth' => '',
+                'channel_data' => 'Hello',
+            ],
+        ])
+    );
+
+    $connection->assertReceived([
+        'event' => 'pusher:error',
+        'data' => json_encode([
+            'code' => 4200,
+            'message' => 'Invalid message format',
+        ]),
+    ]);
+});
+
+it('sends an error if something fails for channel type', function () {
+
+    $this->server->message(
+        $connection = new FakeConnection,
+        json_encode([
+            'event' => 'client-start-typing',
+            'channel' => [],
+        ])
+    );
+
+    $connection->assertReceived([
+        'event' => 'pusher:error',
+        'data' => json_encode([
+            'code' => 4200,
+            'message' => 'Invalid message format',
+        ]),
+    ]);
+});
 
 it('can subscribe a user to a channel', function () {
     $this->server->message(


### PR DESCRIPTION
<img width="1278" alt="Screenshot 1403-10-22 at 14 17 45" src="https://github.com/user-attachments/assets/13d60062-1aa5-4584-991e-82eab7998073" />

As you can see in the image, when the channel is not in string format, the socket drops and restarts. This issue also exists on its main site https://reverb.laravel.com/.


`{"event":"pusher:subscribe","data":{"auth":"","channel":{}}}`

error: 
`[2025-01-09 07:17:24] local.ERROR: json_decode(): Argument #1 ($json) must be of type string, array given {"exception":"[object] (TypeError(code: 0): json_decode(): Argument #1 ($json) must be of type string, array given at /vendor/laravel/reverb/src/Loggers/CliLogger.php:56)
[stacktrace]`

Fixes #298  