### PR TITLE
[1.x] Add Message Payload Validation and Improve Channel Data Handling

### DIFF
--- a/src/Loggers/CliLogger.php
+++ b/src/Loggers/CliLogger.php
@@ -52,7 +52,7 @@ class CliLogger implements Logger
             $message['data'] = json_decode($message['data'], true);
         }
 
-        if (isset($message['data']['channel_data'])) {
+        if (isset($message['data']['channel_data']) && is_string($message['data']['channel_data'])) {
             $message['data']['channel_data'] = json_decode($message['data']['channel_data'], true);
         }
 

--- a/src/Protocols/Pusher/Server.php
+++ b/src/Protocols/Pusher/Server.php
@@ -3,6 +3,7 @@
 namespace Laravel\Reverb\Protocols\Pusher;
 
 use Exception;
+use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
 use Laravel\Reverb\Contracts\Connection;
 use Laravel\Reverb\Events\MessageReceived;
@@ -53,6 +54,15 @@ class Server
 
         try {
             $event = json_decode($message, associative: true, flags: JSON_THROW_ON_ERROR);
+
+            Validator::make($event, [
+                'event' => ['required', 'string'],
+                'data' => ['nullable', 'array'],
+                'channel' => ['nullable', 'string'],
+                'data.channel' => ['required', 'string'],
+                'data.auth' => ['nullable', 'string'],
+                'data.channel_data' => ['nullable', 'json'],
+            ])->validate();
 
             match (Str::startsWith($event['event'], 'pusher:')) {
                 true => $this->handler->handle(

--- a/tests/Unit/Protocols/Pusher/ServerTest.php
+++ b/tests/Unit/Protocols/Pusher/ServerTest.php
@@ -329,3 +329,163 @@ it('accepts a connection from an valid origin', function (string $origin, array 
         ['localhost', '*.localhost'],
     ],
 ]);
+
+it('sends an error if something fails for event type', function () {
+
+    $this->server->message(
+        $connection = new FakeConnection,
+        json_encode([
+            'event' => [],
+        ])
+    );
+
+    $connection->assertReceived([
+        'event' => 'pusher:error',
+        'data' => json_encode([
+            'code' => 4200,
+            'message' => 'Invalid message format',
+        ]),
+    ]);
+});
+
+it('sends an error if something fails for data type', function () {
+
+    $this->server->message(
+        $connection = new FakeConnection,
+        json_encode([
+            'event' => 'pusher:subscribe',
+            'data' => 'sfsfsfs',
+        ])
+    );
+
+    $connection->assertReceived([
+        'event' => 'pusher:error',
+        'data' => json_encode([
+            'code' => 4200,
+            'message' => 'Invalid message format',
+        ]),
+    ]);
+});
+
+it('sends an error if something fails for data channel type', function () {
+
+    $this->server->message(
+        $connection = new FakeConnection,
+        json_encode([
+            'event' => 'pusher:subscribe',
+            'data' => [
+                'channel' => [],
+            ],
+        ])
+    );
+
+    $connection->assertReceived([
+        'event' => 'pusher:error',
+        'data' => json_encode([
+            'code' => 4200,
+            'message' => 'Invalid message format',
+        ]),
+    ]);
+
+    $this->server->message(
+        $connection = new FakeConnection,
+        json_encode([
+            'event' => 'pusher:subscribe',
+            'data' => [
+                'channel' => null,
+            ],
+        ])
+    );
+
+    $connection->assertReceived([
+        'event' => 'pusher:error',
+        'data' => json_encode([
+            'code' => 4200,
+            'message' => 'Invalid message format',
+        ]),
+    ]);
+});
+
+it('sends an error if something fails for data auth type', function () {
+
+    $this->server->message(
+        $connection = new FakeConnection,
+        json_encode([
+            'event' => 'pusher:subscribe',
+            'data' => [
+                'channel' => 'presence-test-channel',
+                'auth' => [],
+            ],
+        ])
+    );
+
+    $connection->assertReceived([
+        'event' => 'pusher:error',
+        'data' => json_encode([
+            'code' => 4200,
+            'message' => 'Invalid message format',
+        ]),
+    ]);
+});
+
+it('sends an error if something fails for data channel_data type', function () {
+
+    $this->server->message(
+        $connection = new FakeConnection,
+        json_encode([
+            'event' => 'pusher:subscribe',
+            'data' => [
+                'channel' => 'presence-test-channel',
+                'auth' => '',
+                'channel_data' => [],
+            ],
+        ])
+    );
+
+    $connection->assertReceived([
+        'event' => 'pusher:error',
+        'data' => json_encode([
+            'code' => 4200,
+            'message' => 'Invalid message format',
+        ]),
+    ]);
+
+    $this->server->message(
+        $connection = new FakeConnection,
+        json_encode([
+            'event' => 'pusher:subscribe',
+            'data' => [
+                'channel' => 'presence-test-channel',
+                'auth' => '',
+                'channel_data' => 'Hello',
+            ],
+        ])
+    );
+
+    $connection->assertReceived([
+        'event' => 'pusher:error',
+        'data' => json_encode([
+            'code' => 4200,
+            'message' => 'Invalid message format',
+        ]),
+    ]);
+});
+
+it('sends an error if something fails for channel type', function () {
+
+    $this->server->message(
+        $connection = new FakeConnection,
+        json_encode([
+            'event' => 'client-start-typing',
+            'channel' => [],
+        ])
+    );
+
+    $connection->assertReceived([
+        'event' => 'pusher:error',
+        'data' => json_encode([
+            'code' => 4200,
+            'message' => 'Invalid message format',
+        ]),
+    ]);
+});


### PR DESCRIPTION
## Prerequisites
- Laravel Reverb Server
- PHP 8.1+
- Composer

---

## Description
This pull request introduces improved validation for WebSocket message payloads and enhances the handling of `channel_data`. These changes ensure better stability, prevent server crashes, and align with the latest Laravel best practices.

### Key Changes
1. **Message Payload Validation**: Comprehensive validation added for incoming WebSocket messages.
2. **Improved Channel Data Parsing**: Safely handles `channel_data` JSON parsing to avoid crashes.
3. **Error Handling**: Returns clear error responses for invalid payloads.

---

## Current Behavior
Currently, the server accepts messages without proper validation. This can lead to:
- Server crashes due to invalid data types
- Unexpected behavior caused by malformed `channel_data`
- Missing validation for required fields

#### Example of Problematic Payload:
```json
{
    "event": [],  // Invalid: should be a string
    "data": {
        "channel": null,  // Invalid: should be a string
        "channel_data": "invalid-json",  // Invalid: should be valid JSON
        "auth": []  // Invalid: should be a string
    }
}
```

---

## New Behavior
With this PR:
1. All incoming message payloads are validated.
2. Invalid messages receive proper error responses.
3. `channel_data` is safely parsed and handled.

#### Validation Rules:
```php
Validator::make($event, [
    'event' => ['required', 'string'],
    'data' => ['nullable', 'array'],
    'data.channel' => ['required', 'string'],
    'data.auth' => ['nullable', 'string'],
    'data.channel_data' => ['nullable', 'json'],
])->validate();
```

#### Improved `channel_data` Handling:
```php
if (isset($message['data']['channel_data']) && is_string($message['data']['channel_data'])) {
    $message['data']['channel_data'] = json_decode($message['data']['channel_data'], true);
}
```

---

## Test Coverage
Comprehensive tests have been added in `tests/Unit/Protocols/Pusher/ServerTest.php` to cover:
- Validation for required fields
- Handling of invalid `channel_data`
- Error responses for malformed payloads

#### Example Test Case:
```php
it('sends an error for invalid channel_data type', function () {
    $this->server->message(
        $connection = new FakeConnection,
        json_encode([
            'event' => 'pusher:subscribe',
            'data' => [
                'channel' => 'presence-test-channel',
                'auth' => '',
                'channel_data' => [],
            ],
        ])
    );

    $connection->assertReceived([
        'event' => 'pusher:error',
        'data' => json_encode([
            'code' => 4200,
            'message' => 'Invalid message format',
        ]),
    ]);
});
```

---

## Benefits
- ✅ Prevents server crashes from malformed messages
- ✅ Provides clear and consistent error responses
- ✅ Improves server stability and reliability
- ✅ Maintains compatibility with the Pusher protocol
- ✅ Zero breaking changes

---

## Breaking Changes
None. Invalid messages that previously caused crashes will now receive proper error responses instead.

---

## Related Issues
Fixes #298
