### PR TITLE
[1.x] Adds support for server path prefix

### DIFF
--- a/config/reverb.php
+++ b/config/reverb.php
@@ -31,6 +31,7 @@ return [
         'reverb' => [
             'host' => env('REVERB_SERVER_HOST', '0.0.0.0'),
             'port' => env('REVERB_SERVER_PORT', 8080),
+            'path' => env('REVERB_SERVER_PATH', ''),
             'hostname' => env('REVERB_HOST'),
             'options' => [
                 'tls' => [],

--- a/src/Servers/Reverb/Console/Commands/StartServer.php
+++ b/src/Servers/Reverb/Console/Commands/StartServer.php
@@ -31,6 +31,7 @@ class StartServer extends Command implements SignalableCommandInterface
     protected $signature = 'reverb:start
                 {--host= : The IP address the server should bind to}
                 {--port= : The port the server should listen on}
+                {--path= : The path the server should prefix to all routes}
                 {--hostname= : The hostname the server is accessible from}
                 {--debug : Indicates whether debug messages should be displayed in the terminal}';
 
@@ -57,6 +58,7 @@ class StartServer extends Command implements SignalableCommandInterface
         $server = ServerFactory::make(
             $host = $this->option('host') ?: $config['host'],
             $port = $this->option('port') ?: $config['port'],
+            $path = $this->option('path') ?: $config['path'] ?? '',
             $hostname = $this->option('hostname') ?: $config['hostname'],
             $config['max_request_size'] ?? 10_000,
             $config['options'] ?? [],
@@ -69,7 +71,7 @@ class StartServer extends Command implements SignalableCommandInterface
         $this->ensurePulseEventsAreCollected($loop, $config['pulse_ingest_interval']);
         $this->ensureTelescopeEntriesAreCollected($loop, $config['telescope_ingest_interval'] ?? 15);
 
-        $this->components->info('Starting '.($server->isSecure() ? 'secure ' : '')."server on {$host}:{$port}".(($hostname && $hostname !== $host) ? " ({$hostname})" : ''));
+        $this->components->info('Starting '.($server->isSecure() ? 'secure ' : '')."server on {$host}:{$port}{$path}".(($hostname && $hostname !== $host) ? " ({$hostname})" : ''));
 
         $server->start();
     }

--- a/tests/ReverbTestCase.php
+++ b/tests/ReverbTestCase.php
@@ -83,10 +83,10 @@ class ReverbTestCase extends TestCase
     /**
      * Start the WebSocket server.
      */
-    public function startServer(string $host = '0.0.0.0', string $port = '8080', int $maxRequestSize = 10_000): void
+    public function startServer(string $host = '0.0.0.0', string $port = '8080', string $path = '', int $maxRequestSize = 10_000): void
     {
         $this->resetFiber();
-        $this->server = Factory::make($host, $port, maxRequestSize: $maxRequestSize, loop: $this->loop);
+        $this->server = Factory::make($host, $port, $path, maxRequestSize: $maxRequestSize, loop: $this->loop);
     }
 
     /**
@@ -132,12 +132,12 @@ class ReverbTestCase extends TestCase
     /**
      * Send a request to the server.
      */
-    public function request(string $path, string $method = 'GET', mixed $data = '', string $host = '0.0.0.0', string $port = '8080', string $appId = '123456'): PromiseInterface
+    public function request(string $path, string $method = 'GET', mixed $data = '', string $host = '0.0.0.0', string $port = '8080', string $pathPrefix = '', string $appId = '123456'): PromiseInterface
     {
         return (new Browser($this->loop))
             ->request(
                 $method,
-                "http://{$host}:{$port}/apps/{$appId}/{$path}",
+                "http://{$host}:{$port}{$pathPrefix}/apps/{$appId}/{$path}",
                 [],
                 ($data) ? json_encode($data) : ''
             );
@@ -160,7 +160,7 @@ class ReverbTestCase extends TestCase
     /**
      * Send a signed request to the server.
      */
-    public function signedRequest(string $path, string $method = 'GET', mixed $data = '', string $host = '0.0.0.0', string $port = '8080', string $appId = '123456', string $key = 'reverb-key', string $secret = 'reverb-secret'): PromiseInterface
+    public function signedRequest(string $path, string $method = 'GET', mixed $data = '', string $host = '0.0.0.0', string $port = '8080', string $pathPrefix = '', string $appId = '123456', string $key = 'reverb-key', string $secret = 'reverb-secret'): PromiseInterface
     {
         $timestamp = time();
 
@@ -179,25 +179,25 @@ class ReverbTestCase extends TestCase
             $query .= "&body_md5={$hash}";
         }
 
-        $string = "{$method}\n/apps/{$appId}/{$path}\n$query";
+        $string = "{$method}\n{$pathPrefix}/apps/{$appId}/{$path}\n$query";
         $signature = hash_hmac('sha256', $string, $secret);
 
-        return $this->request("{$path}?{$query}&auth_signature={$signature}", $method, $data, $host, $port, $appId);
+        return $this->request("{$path}?{$query}&auth_signature={$signature}", $method, $data, $host, $port, $pathPrefix, $appId);
     }
 
     /**
      * Send a POST request to the server.
      */
-    public function postRequest(string $path, ?array $data = [], string $host = '0.0.0.0', string $port = '8080', string $appId = '123456'): PromiseInterface
+    public function postRequest(string $path, ?array $data = [], string $host = '0.0.0.0', string $port = '8080', string $pathPrefix = '', string $appId = '123456'): PromiseInterface
     {
-        return $this->request($path, 'POST', $data, $host, $port, $appId);
+        return $this->request($path, 'POST', $data, $host, $port, $pathPrefix, $appId);
     }
 
     /**
      * Send a signed POST request to the server.
      */
-    public function signedPostRequest(string $path, ?array $data = [], string $host = '0.0.0.0', string $port = '8080', string $appId = '123456', $key = 'reverb-key', $secret = 'reverb-secret'): PromiseInterface
+    public function signedPostRequest(string $path, ?array $data = [], string $host = '0.0.0.0', string $port = '8080', string $pathPrefix = '', string $appId = '123456', $key = 'reverb-key', $secret = 'reverb-secret'): PromiseInterface
     {
-        return $this->signedRequest($path, 'POST', $data, $host, $port, $appId, $key, $secret);
+        return $this->signedRequest($path, 'POST', $data, $host, $port, $pathPrefix, $appId, $key, $secret);
     }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

I like having a single domain name to run an application. This allows the server to add a path prefix to all server routes, which will allow it to run at a subpath of an application. This allows for the following (relevant snippets) configuration in an app:
```env
# .env
REVERB_SERVER_PATH="/ws"
REVERB_PATH="/ws"

VITE_REVERB_APP_KEY="${REVERB_APP_KEY}"
VITE_REVERB_HOST="${REVERB_HOST}"
VITE_REVERB_PORT="${REVERB_PORT}"
VITE_REVERB_SCHEME="${REVERB_SCHEME}"
VITE_REVERB_PATH="${REVERB_PATH}"

```
```php
// config/broadcasting.php
    'connections' => [
        'reverb' => [
            'driver' => 'reverb',
            'key' => env('REVERB_APP_KEY'),
            'secret' => env('REVERB_APP_SECRET'),
            'app_id' => env('REVERB_APP_ID'),
            'options' => [
                'host' => env('REVERB_HOST'),
                'port' => env('REVERB_PORT', 443),
                'scheme' => env('REVERB_SCHEME', 'https'),
                'useTLS' => env('REVERB_SCHEME', 'https') === 'https',
                ...(env('REVERB_PATH', '') ? [
                    'base_path' => env('REVERB_PATH') . '/apps/' . env('REVERB_APP_ID'),
                ] : []),
            ],
            'client_options' => [
                // Guzzle client options: https://docs.guzzlephp.org/en/stable/request-options.html
            ],
        ],
    ],

```

```php
// config/reverb.php
    'servers' => [
        'reverb' => [
            'host' => env('REVERB_SERVER_HOST', '0.0.0.0'),
            'port' => env('REVERB_SERVER_PORT', 8080),
            'path' => env('REVERB_SERVER_PATH', ''),
            'hostname' => env('REVERB_HOST'),
        ...
       ]
    ]
```
```nginx
# NGINX config location snippet
    location /ws {
      proxy_pass                          http://127.0.0.1:8080;

      proxy_http_version 1.1;
      proxy_set_header Host $http_host;
      proxy_set_header Scheme $scheme;
      proxy_set_header SERVER_PORT $server_port;
      proxy_set_header REMOTE_ADDR $remote_addr;
      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
      proxy_set_header Upgrade $http_upgrade;
      proxy_set_header Connection "Upgrade";
    }
```

```ts
// echo.ts
const echo = new Echo({
  broadcaster: "reverb",
  key: import.meta.env.VITE_REVERB_APP_KEY,
  wsHost: import.meta.env.VITE_REVERB_HOST,
  wsPort: import.meta.env.VITE_REVERB_PORT ?? 80,
  wssPort: import.meta.env.VITE_REVERB_PORT ?? 443,
  wsPath: import.meta.env.VITE_REVERB_PATH ?? "",
  forceTLS: (import.meta.env.VITE_REVERB_SCHEME ?? "https") === "https",
  enabledTransports: ["ws", "wss"],
});
```