### PR TITLE
Allow client event without data

### DIFF
--- a/src/Protocols/Pusher/ClientEvent.php
+++ b/src/Protocols/Pusher/ClientEvent.php
@@ -16,7 +16,7 @@ class ClientEvent
         Validator::make($event, [
             'event' => ['required', 'string'],
             'channel' => ['required', 'string'],
-            'data' => ['required', 'array'],
+            'data' => ['nullable', 'array'],
         ])->validate();
 
         if (! Str::startsWith($event['event'], 'client-')) {

--- a/tests/Unit/Protocols/Pusher/ServerTest.php
+++ b/tests/Unit/Protocols/Pusher/ServerTest.php
@@ -483,3 +483,15 @@ it('sends an error if something fails for channel type', function () {
         ]),
     ]);
 });
+
+it('allow receiving client event with empty data', function () {
+    $this->server->message(
+        $connection = new FakeConnection,
+        json_encode([
+            'event' => 'client-start-typing',
+            'channel' => 'private-chat.1',
+        ])
+    );
+
+    $connection->assertNothingReceived();
+});


### PR DESCRIPTION
This PR allow client event without data. Added tests to tests/Unit/Protocols/Pusher/ServerTest.php.

## Benefits
- ✅ Ability to send events without data

## Breaking Changes
None.

## Related Issues
Fixes #314.