### PR TITLE
Add event dispatching for server start and Pusher actions

### DIFF
--- a/src/Events/PusherSubscribe.php
+++ b/src/Events/PusherSubscribe.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Laravel\Reverb\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Laravel\Reverb\Contracts\Connection;
+
+class PusherSubscribe
+{
+    use Dispatchable;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(public Connection $connection, public string $channel)
+    {
+        //
+    }
+}

--- a/src/Events/PusherUnsubscribe.php
+++ b/src/Events/PusherUnsubscribe.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Laravel\Reverb\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Laravel\Reverb\Contracts\Connection;
+
+class PusherUnsubscribe
+{
+    use Dispatchable;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(public Connection $connection, public string $channel)
+    {
+        //
+    }
+}

--- a/src/Events/ServerStarted.php
+++ b/src/Events/ServerStarted.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Laravel\Reverb\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Laravel\Reverb\Protocols\Pusher\Channels\ChannelConnection;
+
+class ServerStarted
+{
+    use Dispatchable;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct()
+    {
+        //
+    }
+}

--- a/src/Protocols/Pusher/Channels/Channel.php
+++ b/src/Protocols/Pusher/Channels/Channel.php
@@ -3,6 +3,8 @@
 namespace Laravel\Reverb\Protocols\Pusher\Channels;
 
 use Laravel\Reverb\Contracts\Connection;
+use Laravel\Reverb\Events\PusherSubscribe;
+use Laravel\Reverb\Events\PusherUnsubscribe;
 use Laravel\Reverb\Loggers\Log;
 use Laravel\Reverb\Protocols\Pusher\Concerns\SerializesChannels;
 use Laravel\Reverb\Protocols\Pusher\Contracts\ChannelConnectionManager;
@@ -67,6 +69,7 @@ class Channel
     public function subscribe(Connection $connection, ?string $auth = null, ?string $data = null): void
     {
         $this->connections->add($connection, $data ? json_decode($data, associative: true, flags: JSON_THROW_ON_ERROR) : []);
+        PusherSubscribe::dispatch($connection, $this->name);
     }
 
     /**
@@ -79,6 +82,7 @@ class Channel
         if ($this->connections->isEmpty()) {
             app(ChannelManager::class)->for($connection->app())->remove($this);
         }
+        PusherUnsubscribe::dispatch($connection, $this->name);
     }
 
     /**

--- a/src/Servers/Reverb/Console/Commands/StartServer.php
+++ b/src/Servers/Reverb/Console/Commands/StartServer.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Cache;
 use Laravel\Reverb\Application;
 use Laravel\Reverb\Contracts\ApplicationProvider;
 use Laravel\Reverb\Contracts\Logger;
+use Laravel\Reverb\Events\ServerStarted;
 use Laravel\Reverb\Jobs\PingInactiveConnections;
 use Laravel\Reverb\Jobs\PruneStaleConnections;
 use Laravel\Reverb\Loggers\CliLogger;
@@ -72,7 +73,7 @@ class StartServer extends Command implements SignalableCommandInterface
         $this->ensureTelescopeEntriesAreCollected($loop, $config['telescope_ingest_interval'] ?? 15);
 
         $this->components->info('Starting '.($server->isSecure() ? 'secure ' : '')."server on {$host}:{$port}{$path}".(($hostname && $hostname !== $host) ? " ({$hostname})" : ''));
-
+        ServerStarted::dispatch();
         $server->start();
     }
 


### PR DESCRIPTION
This commit introduces three new events: ServerStarted, PusherSubscribe, and PusherUnsubscribe. These events are dispatched when the server starts, and when clients subscribe or unsubscribe from Pusher channels.

These events enable tracking of client online/offline state from laravel server side.