### PR TITLE
[1.x] Sets X-Powered-By header

### DIFF
--- a/src/Servers/Reverb/Http/Router.php
+++ b/src/Servers/Reverb/Http/Router.php
@@ -103,7 +103,8 @@ class Router
      */
     protected function attemptUpgrade(RequestInterface $request, Connection $connection): ReverbConnection
     {
-        $response = $this->negotiator->handshake($request);
+        $response = $this->negotiator->handshake($request)
+            ->withHeader('X-Powered-By', 'Laravel Reverb');
 
         $connection->write(Message::toString($response));
 

--- a/tests/Feature/Protocols/Pusher/Reverb/ServerTest.php
+++ b/tests/Feature/Protocols/Pusher/Reverb/ServerTest.php
@@ -14,7 +14,6 @@ use function React\Async\await;
 uses(ReverbTestCase::class);
 
 it('can handle connections to different applications', function () {
-    connect();
     connect(key: 'reverb-key-2');
     connect(key: 'reverb-key-3', headers: ['Origin' => 'http://laravel.com']);
 });
@@ -560,4 +559,10 @@ it('uses control frames when the client prefers', function () {
 
     $connection->assertPinged();
     $connection->assertNotReceived('{"event":"pusher:ping"}');
+});
+
+it('sets the x-powered-by header', function () {
+    $connection = connect();
+    
+    expect($connection->connection->response->getHeader('X-Powered-By')[0])->toBe('Laravel Reverb');
 });


### PR DESCRIPTION
Sets the `X-Powered-By` response header for the initial connection to "Laravel Reverb"

**Current**
<img width="590" alt="Screenshot 2025-03-30 at 19 33 17" src="https://github.com/user-attachments/assets/17c9bbc9-f64e-435b-9305-b32f23514ce9" />

**Updated**
<img width="608" alt="Screenshot 2025-03-30 at 19 32 10" src="https://github.com/user-attachments/assets/a0c73654-b2d0-4558-b092-d01c4a76b333" />
