### PR TITLE
[1.x] Fix issue with quoted string in .env when running install command

### DIFF
--- a/src/Console/Commands/InstallCommand.php
+++ b/src/Console/Commands/InstallCommand.php
@@ -180,7 +180,7 @@ class InstallCommand extends Command
 
         File::put(
             $env,
-            Str::of(File::get($env))->replaceMatches('/(BROADCAST_(?:DRIVER|CONNECTION))=\w*/', function (array $matches) {
+            Str::of(File::get($env))->replaceMatches('/(BROADCAST_(?:DRIVER|CONNECTION))=.*/', function (array $matches) {
                 return $matches[1].'=reverb';
             })
         );


### PR DESCRIPTION
Fixes #309 by matching one or more of any character (rather than word, digit or whitespace only) after `BROADCAST_DRIVER=` or `BROADCAST_CONNECTION=` in the `.env` during the `reverb:install` command.