### PR TITLE
Fix encoding of data field in presence channel events to match Pusher protocol

### DIFF
--- a/src/Protocols/Pusher/Channels/Concerns/InteractsWithPresenceChannels.php
+++ b/src/Protocols/Pusher/Channels/Concerns/InteractsWithPresenceChannels.php
@@ -28,7 +28,7 @@ trait InteractsWithPresenceChannels
         parent::broadcastInternally(
             [
                 'event' => 'pusher_internal:member_added',
-                'data' => $userData,
+                'data' => json_encode((object) $userData),
                 'channel' => $this->name(),
             ],
             $connection
@@ -55,7 +55,7 @@ trait InteractsWithPresenceChannels
         parent::broadcast(
             [
                 'event' => 'pusher_internal:member_removed',
-                'data' => ['user_id' => $subscription->data('user_id')],
+                'data' => json_encode(['user_id' => $subscription->data('user_id')]),
                 'channel' => $this->name(),
             ],
             $connection

--- a/tests/Feature/Protocols/Pusher/Reverb/ServerTest.php
+++ b/tests/Feature/Protocols/Pusher/Reverb/ServerTest.php
@@ -71,8 +71,8 @@ it('can notify other subscribers of a presence channel when a new member joins',
     $data = ['user_id' => 3, 'user_info' => ['name' => 'Test User 3']];
     subscribe('presence-test-channel', data: $data);
 
-    $connectionOne->assertReceived('{"event":"pusher_internal:member_added","data":{"user_id":2,"user_info":{"name":"Test User 2"}},"channel":"presence-test-channel"}');
-    $connectionTwo->assertReceived('{"event":"pusher_internal:member_added","data":{"user_id":3,"user_info":{"name":"Test User 3"}},"channel":"presence-test-channel"}');
+    $connectionOne->assertReceived('{"event":"pusher_internal:member_added","data":"{\"user_id\":2,\"user_info\":{\"name\":\"Test User 2\"}}","channel":"presence-test-channel"}');
+    $connectionTwo->assertReceived('{"event":"pusher_internal:member_added","data":"{\"user_id\":3,\"user_info\":{\"name\":\"Test User 3\"}}","channel":"presence-test-channel"}');
 });
 
 it('can notify other subscribers of a presence channel when a member leaves', function () {
@@ -88,13 +88,13 @@ it('can notify other subscribers of a presence channel when a member leaves', fu
     $data = ['user_id' => 3, 'user_info' => ['name' => 'Test User 3']];
     subscribe('presence-test-channel', data: $data, connection: $connectionThree);
 
-    $connectionOne->assertReceived('{"event":"pusher_internal:member_added","data":{"user_id":2,"user_info":{"name":"Test User 2"}},"channel":"presence-test-channel"}');
-    $connectionTwo->assertReceived('{"event":"pusher_internal:member_added","data":{"user_id":3,"user_info":{"name":"Test User 3"}},"channel":"presence-test-channel"}');
+    $connectionOne->assertReceived('{"event":"pusher_internal:member_added","data":"{\"user_id\":2,\"user_info\":{\"name\":\"Test User 2\"}}","channel":"presence-test-channel"}');
+    $connectionTwo->assertReceived('{"event":"pusher_internal:member_added","data":"{\"user_id\":3,\"user_info\":{\"name\":\"Test User 3\"}}","channel":"presence-test-channel"}');
 
     disconnect($connectionThree);
 
-    $connectionOne->assertReceived('{"event":"pusher_internal:member_removed","data":{"user_id":3},"channel":"presence-test-channel"}');
-    $connectionTwo->assertReceived('{"event":"pusher_internal:member_removed","data":{"user_id":3},"channel":"presence-test-channel"}');
+    $connectionOne->assertReceived('{"event":"pusher_internal:member_removed","data":"{\"user_id\":3}","channel":"presence-test-channel"}');
+    $connectionTwo->assertReceived('{"event":"pusher_internal:member_removed","data":"{\"user_id\":3}","channel":"presence-test-channel"}');
 });
 
 it('can receive a cached message when joining a cache channel', function () {

--- a/tests/Unit/Protocols/Pusher/Channels/PresenceCacheChannelTest.php
+++ b/tests/Unit/Protocols/Pusher/Channels/PresenceCacheChannelTest.php
@@ -96,7 +96,7 @@ it('sends notification of subscription', function () {
 
     collect($connections)->each(fn ($connection) => $connection->assertReceived([
         'event' => 'pusher_internal:member_added',
-        'data' => [],
+        'data' => '{}',
         'channel' => 'presence-cache-test-channel',
     ]));
 });
@@ -124,7 +124,7 @@ it('sends notification of subscription with data', function () {
 
     collect($connections)->each(fn ($connection) => $connection->assertReceived([
         'event' => 'pusher_internal:member_added',
-        'data' => ['name' => 'Joe'],
+        'data' => json_encode(['name' => 'Joe']),
         'channel' => 'presence-cache-test-channel',
     ]));
 });
@@ -157,7 +157,7 @@ it('sends notification of an unsubscribe', function () {
 
     collect($connections)->each(fn ($connection) => $connection->assertReceived([
         'event' => 'pusher_internal:member_removed',
-        'data' => ['user_id' => 1],
+        'data' => json_encode(['user_id' => 1]),
         'channel' => 'presence-cache-test-channel',
     ]));
 });

--- a/tests/Unit/Protocols/Pusher/Channels/PresenceChannelTest.php
+++ b/tests/Unit/Protocols/Pusher/Channels/PresenceChannelTest.php
@@ -96,7 +96,7 @@ it('sends notification of subscription', function () {
 
     collect($connections)->each(fn ($connection) => $connection->assertReceived([
         'event' => 'pusher_internal:member_added',
-        'data' => [],
+        'data' => '{}',
         'channel' => 'presence-test-channel',
     ]));
 });
@@ -124,7 +124,7 @@ it('sends notification of subscription with data', function () {
 
     collect($connections)->each(fn ($connection) => $connection->assertReceived([
         'event' => 'pusher_internal:member_added',
-        'data' => ['name' => 'Joe'],
+        'data' => json_encode(['name' => 'Joe']),
         'channel' => 'presence-test-channel',
     ]));
 });
@@ -157,7 +157,7 @@ it('sends notification of an unsubscribe', function () {
 
     collect($connections)->each(fn ($connection) => $connection->assertReceived([
         'event' => 'pusher_internal:member_removed',
-        'data' => ['user_id' => 1],
+        'data' => json_encode(['user_id' => 1]),
         'channel' => 'presence-test-channel',
     ]));
 });


### PR DESCRIPTION
**Background**
Previously, the `data` field in presence channel events (`member_added`, `member_removed`) was sent as an object, not as a JSON-encoded string per the Pusher protocol. This caused client compatibility issues.

* [Pusher protocol for `member_added`](https://pusher.com/docs/channels/library_auth_reference/pusher-websockets-protocol/#pusher_internalmember_added-pusher-channels-greater-client)
* [Pusher protocol for `member_removed`](https://pusher.com/docs/channels/library_auth_reference/pusher-websockets-protocol/#pusher_internalmember_removed-pusher-channels-greater-client)

**What was fixed**

* Now, the `data` field is always a JSON-encoded string, as required by Pusher.
* Updated related tests to expect the correct format.
* Ensured empty data is sent as `'{}'`.