### PR TITLE
Laravel Reverb with Presence Channel Events

### DIFF
--- a/src/Events/PresenceChannelSubscribe.php
+++ b/src/Events/PresenceChannelSubscribe.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Laravel\Reverb\Events;
+
+use Laravel\Reverb\Contracts\Connection;
+use Illuminate\Foundation\Events\Dispatchable;
+class PresenceChannelSubscribe
+
+{
+    use Dispatchable;
+    public function __construct(
+        public string $channel,
+        public Connection $connection
+    ) {}
+    
+
+
+}

--- a/src/Events/PresenceChannelUnsubscribe.php
+++ b/src/Events/PresenceChannelUnsubscribe.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Laravel\Reverb\Events;
+
+use Laravel\Reverb\Contracts\Connection;
+use Illuminate\Foundation\Events\Dispatchable;
+class PresenceChannelUnsubscribe
+
+{
+    use Dispatchable;
+    public function __construct(
+        public string $channel,
+        public Connection $connection
+    ) {}
+    
+
+
+}

--- a/src/Protocols/Pusher/Channels/Concerns/InteractsWithPresenceChannels.php
+++ b/src/Protocols/Pusher/Channels/Concerns/InteractsWithPresenceChannels.php
@@ -3,6 +3,8 @@
 namespace Laravel\Reverb\Protocols\Pusher\Channels\Concerns;
 
 use Laravel\Reverb\Contracts\Connection;
+use Laravel\Reverb\Events\PresenceChannelSubscribe;
+use Laravel\Reverb\Events\PresenceChannelUnsubscribe;
 
 trait InteractsWithPresenceChannels
 {
@@ -24,6 +26,8 @@ trait InteractsWithPresenceChannels
         }
 
         parent::subscribe($connection, $auth, $data);
+
+        PresenceChannelSubscribe::dispatch($this->name(),$connection);
 
         parent::broadcastInternally(
             [
@@ -52,6 +56,8 @@ trait InteractsWithPresenceChannels
             return;
         }
 
+        PresenceChannelUnsubscribe::dispatch($this->name(), $connection);
+        
         parent::broadcast(
             [
                 'event' => 'pusher_internal:member_removed',


### PR DESCRIPTION
## Motivation

This fork of **Laravel Reverb** introduces internal event dispatching for **presence channel** activity (`subscribe` and `unsubscribe`) at the server level. The primary motivation for this change is to overcome a limitation when using [Pusher](https://pusher.com/), while Pusher provides [webhook](https://pusher.com/docs/channels/server_api/webhooks/#member_removed) support for presence channel events (like `member_added` and `member_removed`), **those events are not directly observable or actionable from within the Laravel backend itself** unless relying on external HTTP webhooks.

This limitation makes it difficult to:

* Track which users are currently connected to presence channels.
* Maintain accurate counts of connected clients.
* Trigger internal business logic when a user joins or leaves a presence channel.

---

## What this fork adds

This fork introduces the following improvements:

### 1. **Custom Laravel Events** for presence channels:

* `PresenceChannelSubscribe`: Dispatched whenever a user subscribes to a presence channel **for the first time** (per `user_id`).
* `PresenceChannelUnsubscribe`: Dispatched whenever a user **fully disconnects** from a presence channel (i.e., no other connections remain with the same `user_id`).

These events are dispatched within the `InteractsWithPresenceChannels` trait and provide access to:

* The channel name
* The `Connection` instance (which includes `app id`, `socket id`, etc.)

### 2. **Better visibility and control**:

With these events, your Laravel backend can now:

* Log or audit connection activity.
* Broadcast additional internal events.
* Update metrics or cache based on real-time channel activity.
* Implement custom presence tracking for dashboards or analytics.

---

## Example: Listening to the events

You can listen to the new events like any other Laravel events:

```php
use Laravel\Reverb\Events\PresenceChannelSubscribe;
use Laravel\Reverb\Events\PresenceChannelUnsubscribe;

Event::listen(PresenceChannelSubscribe::class, function ($event) {
    Log::info("User subscribed to presence channel", [
        'channel' => $event->channel,
        'socket_id' => $event->connection->socketId(),
    ]);
});

Event::listen(PresenceChannelUnsubscribe::class, function ($event) {
    Log::info("User unsubscribed from presence channel", [
        'channel' => $event->channel,
        'socket_id' => $event->connection->socketId(),
    ]);
});
```

---

## Implementation details

The logic is located inside the `InteractsWithPresenceChannels` trait, where:

* Before broadcasting `member_added`, the server checks if this is the first connection for that `user_id`.
* Before broadcasting `member_removed`, the server verifies that no other connections remain for the same `user_id`.

This mimics Pusher's behavior while giving you full control in Laravel.
