### PR TITLE
Remove re-subscription logic in scaling mode

### DIFF
--- a/src/Servers/Reverb/Publishing/RedisPubSubProvider.php
+++ b/src/Servers/Reverb/Publishing/RedisPubSubProvider.php
@@ -68,12 +68,6 @@ class RedisPubSubProvider implements PubSubProvider
         $this->subscriber->on('message', function (string $channel, string $payload) {
             $this->messageHandler->handle($payload);
         });
-
-        $this->subscriber->on('unsubscribe', function (string $channel) {
-            if ($this->channel === $channel) {
-                $this->subscriber->subscribe($channel);
-            }
-        });
     }
 
     /**

--- a/tests/Unit/Servers/Reverb/Publishing/RedisPubSubProviderTest.php
+++ b/tests/Unit/Servers/Reverb/Publishing/RedisPubSubProviderTest.php
@@ -16,44 +16,6 @@ afterAll(function () {
     $property->setValue($loop, null);
 });
 
-it('resubscribes to the scaling channel on unsubscribe event', function () {
-    $channel = 'reverb';
-    $subscriber = Mockery::mock(Client::class);
-
-    $subscriber->shouldReceive('on')
-        ->with('unsubscribe', Mockery::on(function ($callback) use ($channel) {
-            $callback($channel);
-
-            return true;
-        }))->once();
-
-    $subscriber->shouldReceive('on')
-        ->with('message', Mockery::any())
-        ->zeroOrMoreTimes();
-
-    $subscriber->shouldReceive('on')
-        ->with('close', Mockery::any())
-        ->zeroOrMoreTimes();
-
-    $subscriber->shouldReceive('subscribe')
-        ->twice()
-        ->with($channel);
-
-    $clientFactory = Mockery::mock(RedisClientFactory::class);
-
-    // The first call to make() will return a publishing client
-    $clientFactory->shouldReceive('make')
-        ->once()
-        ->andReturn(new Promise(fn (callable $resolve) => $resolve));
-
-    $clientFactory->shouldReceive('make')
-        ->once()
-        ->andReturn(new Promise(fn (callable $resolve) => $resolve($subscriber)));
-
-    $provider = new RedisPubSubProvider($clientFactory, Mockery::mock(PubSubIncomingMessageHandler::class), $channel);
-    $provider->connect(Mockery::mock(LoopInterface::class));
-});
-
 it('can successfully reconnect', function () {
     $clientFactory = Mockery::mock(RedisClientFactory::class);
     $loop = Mockery::mock(LoopInterface::class);


### PR DESCRIPTION
This logic was originally introduced in #251 due to the use of createLazyClient(). Since it was replaced with createClient() in #281, it is no longer needed.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
