### PR TITLE
[1.x] Adds optional application level connection limits

### DIFF
--- a/config/reverb.php
+++ b/config/reverb.php
@@ -85,6 +85,7 @@ return [
                 'allowed_origins' => ['*'],
                 'ping_interval' => env('REVERB_APP_PING_INTERVAL', 60),
                 'activity_timeout' => env('REVERB_APP_ACTIVITY_TIMEOUT', 30),
+                'max_connections' => env('REVERB_APP_MAX_CONNECTIONS'),
                 'max_message_size' => env('REVERB_APP_MAX_MESSAGE_SIZE', 10_000),
             ],
         ],

--- a/src/Application.php
+++ b/src/Application.php
@@ -72,7 +72,7 @@ class Application
     }
 
     /**
-     * Get the maximum connection allowed for the application.
+     * Get the maximum connections allowed for the application.
      */
     public function maxConnections(): ?int
     {

--- a/src/Application.php
+++ b/src/Application.php
@@ -15,6 +15,7 @@ class Application
         protected int $activityTimeout,
         protected array $allowedOrigins,
         protected int $maxMessageSize,
+        protected ?int $maxConnections = null,
         protected array $options = [],
     ) {
         //
@@ -68,6 +69,22 @@ class Application
     public function activityTimeout(): int
     {
         return $this->activityTimeout;
+    }
+
+    /**
+     * Get the maximum connection allowed for the application.
+     */
+    public function maxConnections(): ?int
+    {
+        return $this->maxConnections;
+    }
+
+    /**
+     * Determine if the application has a maximum connection limit.
+     */
+    public function hasMaxConnectionLimit(): bool
+    {
+        return $this->maxConnections !== null;
     }
 
     /**

--- a/src/ConfigApplicationProvider.php
+++ b/src/ConfigApplicationProvider.php
@@ -69,6 +69,7 @@ class ConfigApplicationProvider implements ApplicationProvider
             $app['activity_timeout'] ?? 30,
             $app['allowed_origins'],
             $app['max_message_size'],
+            $app['max_connections'] ?? null,
             $app['options'] ?? [],
         );
     }

--- a/src/Protocols/Pusher/Exceptions/ConnectionLimitExceeded.php
+++ b/src/Protocols/Pusher/Exceptions/ConnectionLimitExceeded.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Laravel\Reverb\Protocols\Pusher\Exceptions;
+
+class ConnectionLimitExceeded extends PusherException
+{
+    /**
+     * The error code associated with the exception.
+     *
+     * @var int
+     */
+    protected $code = 4004;
+
+    /**
+     * The error message associated with the exception.
+     *
+     * @var string
+     */
+    protected $message = 'Application is over connection quota';
+}

--- a/src/Protocols/Pusher/Server.php
+++ b/src/Protocols/Pusher/Server.php
@@ -133,6 +133,22 @@ class Server
     }
 
     /**
+     * Ensure the server is within the connection limit.
+     */
+    protected function ensureWithinConnectionLimit(Connection $connection): void
+    {
+        if (! $connection->app()->hasMaxConnectionLimit()) {
+            return;
+        }
+
+        $connections = $this->channels->for($connection->app())->connections();
+
+        if (count($connections) >= $connection->app()->maxConnections()) {
+            throw new ConnectionLimitExceeded;
+        }
+    }
+
+    /**
      * Verify the origin of the connection.
      *
      * @throws \Laravel\Reverb\Exceptions\InvalidOrigin
@@ -154,21 +170,5 @@ class Server
         }
 
         throw new InvalidOrigin;
-    }
-
-    /**
-     * Ensure the server is within the connection limit.
-     */
-    protected function ensureWithinConnectionLimit(Connection $connection): void
-    {
-        if (! $connection->app()->hasMaxConnectionLimit()) {
-            return;
-        }
-
-        $connections = $this->channels->for($connection->app())->connections();
-
-        if (count($connections) >= $connection->app()->maxConnections()) {
-            throw new ConnectionLimitExceeded;
-        }
     }
 }

--- a/src/Protocols/Pusher/Server.php
+++ b/src/Protocols/Pusher/Server.php
@@ -9,6 +9,7 @@ use Laravel\Reverb\Contracts\Connection;
 use Laravel\Reverb\Events\MessageReceived;
 use Laravel\Reverb\Loggers\Log;
 use Laravel\Reverb\Protocols\Pusher\Contracts\ChannelManager;
+use Laravel\Reverb\Protocols\Pusher\Exceptions\ConnectionLimitExceeded;
 use Laravel\Reverb\Protocols\Pusher\Exceptions\InvalidOrigin;
 use Laravel\Reverb\Protocols\Pusher\Exceptions\PusherException;
 use Ratchet\RFC6455\Messaging\Frame;
@@ -31,6 +32,7 @@ class Server
     public function open(Connection $connection): void
     {
         try {
+            $this->ensureWithinConnectionLimit($connection);
             $this->verifyOrigin($connection);
 
             $connection->touch();
@@ -152,5 +154,21 @@ class Server
         }
 
         throw new InvalidOrigin;
+    }
+
+    /**
+     * Ensure the server is within the connection limit.
+     */
+    protected function ensureWithinConnectionLimit(Connection $connection): void
+    {
+        if (! $connection->app()->hasMaxConnectionLimit()) {
+            return;
+        }
+
+        $connections = $this->channels->for($connection->app())->connections();
+
+        if (count($connections) >= $connection->app()->maxConnections()) {
+            throw new ConnectionLimitExceeded;
+        }
     }
 }

--- a/tests/FakeApplicationProvider.php
+++ b/tests/FakeApplicationProvider.php
@@ -21,7 +21,7 @@ class FakeApplicationProvider implements ApplicationProvider
     public function __construct()
     {
         $this->apps = collect([
-            new Application('id', 'key', 'secret', 60, 30, ['*'], 10_000, [
+            new Application('id', 'key', 'secret', 60, 30, ['*'], 10_000, options: [
                 'host' => 'localhost',
                 'port' => 443,
                 'scheme' => 'https',

--- a/tests/Feature/Protocols/Pusher/Reverb/ServerTest.php
+++ b/tests/Feature/Protocols/Pusher/Reverb/ServerTest.php
@@ -387,6 +387,22 @@ it('can connect from a valid origin', function () {
     connect();
 });
 
+it('cannot connect when over the max connection limit', function () {
+    subscribe('test-channel', connection: connect(key: 'reverb-key-2'));
+
+    $connection = await(wsConnect('ws://0.0.0.0:8080/app/reverb-key-2'));
+
+    $promise = new Deferred;
+
+    $connection->on('message', function ($message) use ($promise) {
+        $promise->resolve((string) $message);
+    });
+    
+    $message = await($promise->promise());
+
+    expect($message)->toBe('{"event":"pusher:error","data":"{\"code\":4004,\"message\":\"Application is over connection quota\"}"}');
+});
+
 it('limits the size of messages', function () {
     $connection = connect(key: 'reverb-key-3', headers: ['Origin' => 'http://laravel.com']);
     send(['This message is waaaaaay longer than the 1 byte limit'], $connection);

--- a/tests/ReverbTestCase.php
+++ b/tests/ReverbTestCase.php
@@ -55,6 +55,7 @@ class ReverbTestCase extends TestCase
             'ping_interval' => 10,
             'activity_timeout' => 30,
             'max_message_size' => 1_000_000,
+            'max_connections' => 1,
         ]);
 
         $app['config']->set('reverb.apps.apps.2', [

--- a/tests/Unit/Protocols/Pusher/ServerTest.php
+++ b/tests/Unit/Protocols/Pusher/ServerTest.php
@@ -330,6 +330,29 @@ it('accepts a connection from an valid origin', function (string $origin, array 
     ],
 ]);
 
+it('it rejects a connection when the app is over the connection limit', function () {
+    $this->app['config']->set('reverb.apps.apps.0.max_connections', 1);
+    $this->server->open($connection = new FakeConnection);
+    $this->server->message(
+        $connection,
+        json_encode([
+            'event' => 'pusher:subscribe',
+            'data' => [
+                'channel' => 'my-channel',
+            ],
+        ])
+    );
+    $this->server->open($connectionTwo = new FakeConnection);
+
+    $connectionTwo->assertReceived([
+        'event' => 'pusher:error',
+        'data' => json_encode([
+            'code' => 4004,
+            'message' => 'Application is over connection quota',
+        ]),
+    ]);
+});
+
 it('sends an error if something fails for event type', function () {
     $this->server->message(
         $connection = new FakeConnection,


### PR DESCRIPTION
This PR adds support for connection limits for those users who wish to limit the number of active connections to a given application as [supported by the Pusher protocol](https://pusher.com/docs/channels/library_auth_reference/pusher-websockets-protocol/#4000-4099).

<img width="376" height="61" alt="Screenshot 2025-09-06 at 12 58 41" src="https://github.com/user-attachments/assets/e2b1dfd3-61a9-48f9-b412-84648096b572" />

This is opt-in functionality to preserve backward compatibility.
