### PR TITLE
Update reverb.php to include redis scheme option

### DIFF
--- a/config/reverb.php
+++ b/config/reverb.php
@@ -48,6 +48,7 @@ return [
                     'password' => env('REDIS_PASSWORD'),
                     'database' => env('REDIS_DB', '0'),
                     'timeout' => env('REDIS_TIMEOUT', 60),
+                    'scheme' => env('REDIS_SCHEME', 'tcp'),
                 ],
             ],
             'pulse_ingest_interval' => env('REVERB_PULSE_INGEST_INTERVAL', 15),


### PR DESCRIPTION
Add the scheme option to the server when scaling reverb. Scheme option is used in the function to build the final redisURL, but not exposed as an option here. Often the scheme is TLS on production, making the default not work in this case, and there is no documentation on it.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
