### PR TITLE
Decode the client event data if it is a valid json string

### DIFF
--- a/src/Protocols/Pusher/Server.php
+++ b/src/Protocols/Pusher/Server.php
@@ -57,6 +57,7 @@ class Server
 
         try {
             $event = json_decode($message, associative: true, flags: JSON_THROW_ON_ERROR);
+
             if (Str::isJson($event['data'] ?? null)) {
                 $event['data'] = json_decode($event['data'], associative: true, flags: JSON_THROW_ON_ERROR);
             }


### PR DESCRIPTION

## Overview
This PR resolves compatibility issues with the Pusher WebSocket Java client. It adds logic to detect and parse the data field of client messages to an array when the field contains a valid JSON string.

## Related Issue
Resolves #351 
