### PR TITLE
Add per-connection message rate limiting

### DIFF
--- a/config/reverb.php
+++ b/config/reverb.php
@@ -86,6 +86,7 @@ return [
                 'ping_interval' => env('REVERB_APP_PING_INTERVAL', 60),
                 'activity_timeout' => env('REVERB_APP_ACTIVITY_TIMEOUT', 30),
                 'max_connections' => env('REVERB_APP_MAX_CONNECTIONS'),
+                'rate_limit' => env('REVERB_APP_RATE_LIMIT'),
                 'max_message_size' => env('REVERB_APP_MAX_MESSAGE_SIZE', 10_000),
                 'accept_client_events_from' => env('REVERB_APP_ACCEPT_CLIENT_EVENTS_FROM', 'members'),
             ],

--- a/src/Application.php
+++ b/src/Application.php
@@ -16,6 +16,7 @@ class Application
         protected array $allowedOrigins,
         protected int $maxMessageSize,
         protected ?int $maxConnections = null,
+        protected ?int $rateLimit = null,
         protected string $acceptClientEventsFrom = 'members',
         protected array $options = [],
     ) {
@@ -86,6 +87,22 @@ class Application
     public function hasMaxConnectionLimit(): bool
     {
         return $this->maxConnections !== null;
+    }
+
+    /**
+     * Get the maximum number of messages allowed per second.
+     */
+    public function rateLimit(): ?int
+    {
+        return $this->rateLimit;
+    }
+
+    /**
+     * Determine if the application has a message rate limit.
+     */
+    public function hasRateLimit(): bool
+    {
+        return $this->rateLimit !== null;
     }
 
     /**

--- a/src/ConfigApplicationProvider.php
+++ b/src/ConfigApplicationProvider.php
@@ -70,6 +70,7 @@ class ConfigApplicationProvider implements ApplicationProvider
             $app['allowed_origins'],
             $app['max_message_size'],
             $app['max_connections'] ?? null,
+            $app['rate_limit'] ?? null,
             // If no setting is provided, default to allowing all client events...
             $app['accept_client_events_from'] ?? 'all',
             $app['options'] ?? [],

--- a/src/Contracts/Connection.php
+++ b/src/Contracts/Connection.php
@@ -23,6 +23,13 @@ abstract class Connection
     protected $usesControlFrames = false;
 
     /**
+     * The timestamps of recent messages for rate limiting.
+     *
+     * @var array<int, int>
+     */
+    protected array $messageTimestamps = [];
+
+    /**
      * Create a new connection instance.
      */
     public function __construct(protected WebSocketConnection $connection, protected Application $application, protected ?string $origin)
@@ -164,5 +171,27 @@ abstract class Connection
         $this->usesControlFrames = $usesControlFrames;
 
         return $this;
+    }
+
+    /**
+     * Record a message timestamp for rate limiting.
+     */
+    public function recordMessage(): void
+    {
+        $this->messageTimestamps[] = time();
+    }
+
+    /**
+     * Get the number of messages sent within the given number of seconds.
+     */
+    public function messageCount(int $seconds = 1): int
+    {
+        $threshold = time() - $seconds;
+
+        $this->messageTimestamps = array_values(
+            array_filter($this->messageTimestamps, fn (int $timestamp) => $timestamp >= $threshold)
+        );
+
+        return count($this->messageTimestamps);
     }
 }

--- a/src/Protocols/Pusher/Exceptions/MessageRateLimitExceeded.php
+++ b/src/Protocols/Pusher/Exceptions/MessageRateLimitExceeded.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Laravel\Reverb\Protocols\Pusher\Exceptions;
+
+class MessageRateLimitExceeded extends PusherException
+{
+    /**
+     * The error code associated with the exception.
+     *
+     * @var int
+     */
+    protected $code = 4005;
+
+    /**
+     * The error message associated with the exception.
+     *
+     * @var string
+     */
+    protected $message = 'Rate limit exceeded';
+}

--- a/src/Protocols/Pusher/Server.php
+++ b/src/Protocols/Pusher/Server.php
@@ -11,6 +11,7 @@ use Laravel\Reverb\Loggers\Log;
 use Laravel\Reverb\Protocols\Pusher\Contracts\ChannelManager;
 use Laravel\Reverb\Protocols\Pusher\Exceptions\ConnectionLimitExceeded;
 use Laravel\Reverb\Protocols\Pusher\Exceptions\InvalidOrigin;
+use Laravel\Reverb\Protocols\Pusher\Exceptions\MessageRateLimitExceeded;
 use Laravel\Reverb\Protocols\Pusher\Exceptions\PusherException;
 use Ratchet\RFC6455\Messaging\Frame;
 use Ratchet\RFC6455\Messaging\FrameInterface;
@@ -56,6 +57,10 @@ class Server
         $from->touch();
 
         try {
+            $this->ensureWithinMessageRateLimit($from);
+
+            $from->recordMessage();
+
             $event = json_decode($message, associative: true, flags: JSON_THROW_ON_ERROR);
 
             if (Str::isJson($event['data'] ?? null)) {
@@ -149,6 +154,20 @@ class Server
 
         if (count($connections) >= $connection->app()->maxConnections()) {
             throw new ConnectionLimitExceeded;
+        }
+    }
+
+    /**
+     * Ensure the connection is within the message rate limit.
+     */
+    protected function ensureWithinMessageRateLimit(Connection $connection): void
+    {
+        if (! $connection->app()->hasRateLimit()) {
+            return;
+        }
+
+        if ($connection->messageCount() >= $connection->app()->rateLimit()) {
+            throw new MessageRateLimitExceeded;
         }
     }
 

--- a/tests/Unit/Protocols/Pusher/ServerTest.php
+++ b/tests/Unit/Protocols/Pusher/ServerTest.php
@@ -353,6 +353,59 @@ it('it rejects a connection when the app is over the connection limit', function
     ]);
 });
 
+it('rejects a message when the connection exceeds the rate limit', function () {
+    $this->app['config']->set('reverb.apps.apps.0.rate_limit', 3);
+    $this->server->open($connection = new FakeConnection);
+
+    for ($i = 0; $i < 3; $i++) {
+        $this->server->message(
+            $connection,
+            json_encode([
+                'event' => 'pusher:subscribe',
+                'data' => [
+                    'channel' => 'test-channel-'.$i,
+                ],
+            ])
+        );
+    }
+
+    $this->server->message(
+        $connection,
+        json_encode([
+            'event' => 'pusher:subscribe',
+            'data' => [
+                'channel' => 'test-channel-overflow',
+            ],
+        ])
+    );
+
+    $connection->assertReceived([
+        'event' => 'pusher:error',
+        'data' => json_encode([
+            'code' => 4005,
+            'message' => 'Rate limit exceeded',
+        ]),
+    ]);
+});
+
+it('allows messages when no rate limit is configured', function () {
+    $this->server->open($connection = new FakeConnection);
+
+    for ($i = 0; $i < 10; $i++) {
+        $this->server->message(
+            $connection,
+            json_encode([
+                'event' => 'pusher:subscribe',
+                'data' => [
+                    'channel' => 'test-channel-'.$i,
+                ],
+            ])
+        );
+    }
+
+    $connection->assertReceivedCount(11);
+});
+
 it('sends an error if something fails for event type', function () {
     $this->server->message(
         $connection = new FakeConnection,


### PR DESCRIPTION
## Summary

- Add an optional `rate_limit` config key that caps the number of WebSocket messages a single connection can send per second
- When the limit is exceeded, the connection receives a `pusher:error` with code `4005` and message "Rate limit exceeded"
- When omitted or `null`, no rate limiting is applied (fully backwards compatible)

Currently any WebSocket client can flood Reverb with unlimited messages — this adds a simple, per-connection throttle following the same pattern as `max_connections` (PR #347).

## Changes

| File | Change |
|------|--------|
| `config/reverb.php` | Added `rate_limit` key with `REVERB_APP_RATE_LIMIT` env var |
| `src/Application.php` | Added `rateLimit` parameter, `rateLimit()` and `hasRateLimit()` accessors |
| `src/ConfigApplicationProvider.php` | Passes `rate_limit` config to `Application` constructor |
| `src/Contracts/Connection.php` | Added `recordMessage()` and `messageCount()` for per-connection tracking |
| `src/Protocols/Pusher/Server.php` | Added `ensureWithinMessageRateLimit()` guard in `message()` |
| `src/Protocols/Pusher/Exceptions/MessageRateLimitExceeded.php` | New `PusherException` subclass (code `4005`) |

## Usage

```env
# Allow max 100 messages per second per connection
REVERB_APP_RATE_LIMIT=100
```

## Test plan

- [x] Messages are rejected with `4005` error when rate limit is exceeded
- [x] Unlimited messages are allowed when no rate limit is configured
- [x] All 111 existing unit tests continue to pass

Closes #307