### PR TITLE
Include server path in broadcasting connection config

### DIFF
--- a/src/Console/Commands/InstallCommand.php
+++ b/src/Console/Commands/InstallCommand.php
@@ -118,6 +118,7 @@ class InstallCommand extends Command
                             'port' => env('REVERB_PORT', 443),
                             'scheme' => env('REVERB_SCHEME', 'https'),
                             'useTLS' => env('REVERB_SCHEME', 'https') === 'https',
+                            'path' => env('REVERB_SERVER_PATH', ''),
                         ],
                         'client_options' => [
                             // Guzzle client options: https://docs.guzzlephp.org/en/stable/request-options.html


### PR DESCRIPTION
## Summary

- When `REVERB_SERVER_PATH` is configured, the Reverb server prefixes all routes (WebSocket and HTTP API) with the specified path. However, the broadcasting connection config generated by `reverb:install` did not pass this path to the Pusher PHP SDK's options.
- This caused the broadcasting driver to send API requests to incorrect URLs (e.g., `/apps/{id}/events` instead of `/{path}/apps/{id}/events`), resulting in 404 errors when broadcasting events.
- Adds `'path' => env('REVERB_SERVER_PATH', '')` to the Pusher SDK options in the generated broadcasting config.

Fixes #361

## Test plan

- [ ] Run `reverb:install` on a fresh Laravel app and verify the broadcasting config includes the `path` option
- [ ] Set `REVERB_SERVER_PATH=ws` and verify that broadcasting events reach the Reverb server correctly
- [ ] Verify that without `REVERB_SERVER_PATH` set (default empty string), broadcasting continues to work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)