### PR TITLE
Add configurable rate limiting for WebSocket messages

### DIFF
--- a/config/reverb.php
+++ b/config/reverb.php
@@ -87,6 +87,7 @@ return [
                 'activity_timeout' => env('REVERB_APP_ACTIVITY_TIMEOUT', 30),
                 'max_connections' => env('REVERB_APP_MAX_CONNECTIONS'),
                 'max_message_size' => env('REVERB_APP_MAX_MESSAGE_SIZE', 10_000),
+                'max_message_rate' => env('REVERB_APP_MAX_MESSAGE_RATE'),
                 'accept_client_events_from' => env('REVERB_APP_ACCEPT_CLIENT_EVENTS_FROM', 'members'),
             ],
         ],

--- a/src/Application.php
+++ b/src/Application.php
@@ -17,6 +17,7 @@ class Application
         protected int $maxMessageSize,
         protected ?int $maxConnections = null,
         protected string $acceptClientEventsFrom = 'members',
+        protected ?int $maxMessageRate = null,
         protected array $options = [],
     ) {
         //
@@ -105,6 +106,14 @@ class Application
     }
 
     /**
+     * Get the maximum number of messages allowed per second per connection.
+     */
+    public function maxMessageRate(): ?int
+    {
+        return $this->maxMessageRate;
+    }
+
+    /**
      * Get the application options.
      */
     public function options(): ?array
@@ -127,6 +136,7 @@ class Application
             'activity_timeout' => $this->activityTimeout,
             'allowed_origins' => $this->allowedOrigins,
             'max_message_size' => $this->maxMessageSize,
+            'max_message_rate' => $this->maxMessageRate,
             'options' => $this->options,
         ];
     }

--- a/src/ConfigApplicationProvider.php
+++ b/src/ConfigApplicationProvider.php
@@ -72,6 +72,7 @@ class ConfigApplicationProvider implements ApplicationProvider
             $app['max_connections'] ?? null,
             // If no setting is provided, default to allowing all client events...
             $app['accept_client_events_from'] ?? 'all',
+            $app['max_message_rate'] ?? null,
             $app['options'] ?? [],
         );
     }

--- a/src/Protocols/Pusher/Exceptions/MessageRateLimitExceeded.php
+++ b/src/Protocols/Pusher/Exceptions/MessageRateLimitExceeded.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Laravel\Reverb\Protocols\Pusher\Exceptions;
+
+class MessageRateLimitExceeded extends PusherException
+{
+    /**
+     * The error code associated with the exception.
+     *
+     * @var int
+     */
+    protected $code = 4301;
+
+    /**
+     * The error message associated with the exception.
+     *
+     * @var string
+     */
+    protected $message = 'Rate limit exceeded';
+}

--- a/src/Protocols/Pusher/Server.php
+++ b/src/Protocols/Pusher/Server.php
@@ -11,6 +11,7 @@ use Laravel\Reverb\Loggers\Log;
 use Laravel\Reverb\Protocols\Pusher\Contracts\ChannelManager;
 use Laravel\Reverb\Protocols\Pusher\Exceptions\ConnectionLimitExceeded;
 use Laravel\Reverb\Protocols\Pusher\Exceptions\InvalidOrigin;
+use Laravel\Reverb\Protocols\Pusher\Exceptions\MessageRateLimitExceeded;
 use Laravel\Reverb\Protocols\Pusher\Exceptions\PusherException;
 use Ratchet\RFC6455\Messaging\Frame;
 use Ratchet\RFC6455\Messaging\FrameInterface;
@@ -18,6 +19,13 @@ use Throwable;
 
 class Server
 {
+    /**
+     * Message timestamps per connection for rate limiting.
+     *
+     * @var array<string, list<float>>
+     */
+    protected array $messageTimestamps = [];
+
     /**
      * Create a new server instance.
      */
@@ -56,6 +64,8 @@ class Server
         $from->touch();
 
         try {
+            $this->ensureWithinMessageRateLimit($from);
+
             $event = json_decode($message, associative: true, flags: JSON_THROW_ON_ERROR);
 
             if (Str::isJson($event['data'] ?? null)) {
@@ -105,6 +115,8 @@ class Server
             ->for($connection->app())
             ->unsubscribeFromAll($connection);
 
+        unset($this->messageTimestamps[$connection->identifier()]);
+
         $connection->disconnect();
 
         Log::info('Connection Closed', $connection->id());
@@ -150,6 +162,38 @@ class Server
         if (count($connections) >= $connection->app()->maxConnections()) {
             throw new ConnectionLimitExceeded;
         }
+    }
+
+    /**
+     * Ensure the connection is within the message rate limit.
+     *
+     * @throws \Laravel\Reverb\Protocols\Pusher\Exceptions\MessageRateLimitExceeded
+     */
+    protected function ensureWithinMessageRateLimit(Connection $connection): void
+    {
+        $maxRate = $connection->app()->maxMessageRate();
+
+        if ($maxRate === null) {
+            return;
+        }
+
+        $id = $connection->identifier();
+        $now = microtime(true);
+        $windowStart = $now - 1.0;
+
+        // Remove timestamps outside the 1-second window.
+        $this->messageTimestamps[$id] = array_values(
+            array_filter(
+                $this->messageTimestamps[$id] ?? [],
+                fn (float $timestamp) => $timestamp > $windowStart
+            )
+        );
+
+        if (count($this->messageTimestamps[$id]) >= $maxRate) {
+            throw new MessageRateLimitExceeded;
+        }
+
+        $this->messageTimestamps[$id][] = $now;
     }
 
     /**


### PR DESCRIPTION
## Summary

- Adds per-connection message rate limiting to prevent abuse from clients sending excessive WebSocket messages.
- Rate limits are configurable per application via the `max_message_rate` config setting (maximum messages per second per connection). When unset (default), rate limiting is disabled.
- When a client exceeds the limit, they receive a `pusher:error` event with code `4301` ("Rate limit exceeded"). The connection remains open so the client can back off.
- Uses an in-memory sliding window of 1 second per connection. Timestamps are automatically cleaned up on disconnect.

### Configuration

Add `REVERB_APP_MAX_MESSAGE_RATE` to `.env` or set `max_message_rate` in the app config:

```php
'apps' => [
    [
        // ...
        'max_message_rate' => env('REVERB_APP_MAX_MESSAGE_RATE', 100),
    ],
],
```

Closes #307

## Test plan

- [ ] Verify that without `max_message_rate` set, messages flow without any rate limiting
- [ ] Set `max_message_rate` to a low value (e.g., 5) and verify that rapid messages trigger the error
- [ ] Verify the client receives `pusher:error` with code `4301` when rate limited
- [ ] Verify the connection remains open after being rate limited
- [ ] Verify memory is cleaned up when connections close
- [ ] Run the existing test suite to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)