### PR TITLE
[1.x] Adds support for rate limiting

### DIFF
--- a/config/reverb.php
+++ b/config/reverb.php
@@ -88,6 +88,12 @@ return [
                 'max_connections' => env('REVERB_APP_MAX_CONNECTIONS'),
                 'max_message_size' => env('REVERB_APP_MAX_MESSAGE_SIZE', 10_000),
                 'accept_client_events_from' => env('REVERB_APP_ACCEPT_CLIENT_EVENTS_FROM', 'members'),
+                'rate_limiting' => [
+                    'enabled' => env('REVERB_APP_RATE_LIMITING_ENABLED', false),
+                    'max_attempts' => env('REVERB_APP_RATE_LIMIT_MAX_ATTEMPTS', 60),
+                    'decay_seconds' => env('REVERB_APP_RATE_LIMIT_DECAY_SECONDS', 60),
+                    'terminate_on_limit' => env('REVERB_APP_RATE_LIMIT_TERMINATE', false),
+                ],
             ],
         ],
 

--- a/src/Application.php
+++ b/src/Application.php
@@ -17,6 +17,7 @@ class Application
         protected int $maxMessageSize,
         protected ?int $maxConnections = null,
         protected string $acceptClientEventsFrom = 'members',
+        protected ?array $rateLimiting = null,
         protected array $options = [],
     ) {
         //
@@ -102,6 +103,22 @@ class Application
     public function acceptClientEventsFrom(): string
     {
         return $this->acceptClientEventsFrom;
+    }
+
+    /**
+     * Get the rate limiting configuration for the application.
+     */
+    public function rateLimiting(): ?array
+    {
+        return $this->rateLimiting;
+    }
+
+    /**
+     * Determine if the application has rate limiting enabled.
+     */
+    public function usesRateLimiting(): bool
+    {
+        return ($this->rateLimiting['enabled'] ?? false) === true;
     }
 
     /**

--- a/src/ConfigApplicationProvider.php
+++ b/src/ConfigApplicationProvider.php
@@ -72,6 +72,7 @@ class ConfigApplicationProvider implements ApplicationProvider
             $app['max_connections'] ?? null,
             // If no setting is provided, default to allowing all client events...
             $app['accept_client_events_from'] ?? 'all',
+            $app['rate_limiting'] ?? null,
             $app['options'] ?? [],
         );
     }

--- a/src/Protocols/Pusher/Exceptions/RateLimitExceeded.php
+++ b/src/Protocols/Pusher/Exceptions/RateLimitExceeded.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Laravel\Reverb\Protocols\Pusher\Exceptions;
+
+class RateLimitExceeded extends PusherException
+{
+    /**
+     * The error code associated with the exception.
+     *
+     * @var int
+     */
+    protected $code = 4301;
+
+    /**
+     * The error message associated with the exception.
+     *
+     * @var string
+     */
+    protected $message = 'Rate limit exceeded';
+}

--- a/src/Protocols/Pusher/Server.php
+++ b/src/Protocols/Pusher/Server.php
@@ -168,6 +168,7 @@ class Server
         $config = $connection->app()->rateLimiting();
 
         $limiter = new RateLimiter(app('cache')->store('array'));
+
         $key = 'reverb:message:'.$connection->id();
 
         if ($limiter->tooManyAttempts($key, $config['max_attempts'])) {

--- a/src/Protocols/Pusher/Server.php
+++ b/src/Protocols/Pusher/Server.php
@@ -3,6 +3,7 @@
 namespace Laravel\Reverb\Protocols\Pusher;
 
 use Exception;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
 use Laravel\Reverb\Contracts\Connection;
@@ -12,6 +13,7 @@ use Laravel\Reverb\Protocols\Pusher\Contracts\ChannelManager;
 use Laravel\Reverb\Protocols\Pusher\Exceptions\ConnectionLimitExceeded;
 use Laravel\Reverb\Protocols\Pusher\Exceptions\InvalidOrigin;
 use Laravel\Reverb\Protocols\Pusher\Exceptions\PusherException;
+use Laravel\Reverb\Protocols\Pusher\Exceptions\RateLimitExceeded;
 use Ratchet\RFC6455\Messaging\Frame;
 use Ratchet\RFC6455\Messaging\FrameInterface;
 use Throwable;
@@ -56,6 +58,8 @@ class Server
         $from->touch();
 
         try {
+            $this->ensureWithinMessageRateLimit($from);
+
             $event = json_decode($message, associative: true, flags: JSON_THROW_ON_ERROR);
 
             if (Str::isJson($event['data'] ?? null)) {
@@ -150,6 +154,30 @@ class Server
         if (count($connections) >= $connection->app()->maxConnections()) {
             throw new ConnectionLimitExceeded;
         }
+    }
+
+    /**
+     * Ensure the connection is within the message rate limit.
+     */
+    protected function ensureWithinMessageRateLimit(Connection $connection): void
+    {
+        if (! $connection->app()->usesRateLimiting()) {
+            return;
+        }
+
+        $config = $connection->app()->rateLimiting();
+
+        $key = 'reverb:message:'.$connection->id();
+
+        if (RateLimiter::tooManyAttempts($key, $config['max_attempts'])) {
+            if ($config['terminate_on_limit'] ?? false) {
+                $connection->terminate();
+            }
+
+            throw new RateLimitExceeded;
+        }
+
+        RateLimiter::increment($key, $config['decay_seconds'] ?? 1);
     }
 
     /**

--- a/src/Protocols/Pusher/Server.php
+++ b/src/Protocols/Pusher/Server.php
@@ -58,7 +58,7 @@ class Server
         $from->touch();
 
         try {
-            $this->ensureWithinMessageRateLimit($from);
+            $this->ensureWithinRateLimit($from);
 
             $event = json_decode($message, associative: true, flags: JSON_THROW_ON_ERROR);
 
@@ -159,7 +159,7 @@ class Server
     /**
      * Ensure the connection is within the message rate limit.
      */
-    protected function ensureWithinMessageRateLimit(Connection $connection): void
+    protected function ensureWithinRateLimit(Connection $connection): void
     {
         if (! $connection->app()->usesRateLimiting()) {
             return;

--- a/src/Protocols/Pusher/Server.php
+++ b/src/Protocols/Pusher/Server.php
@@ -3,7 +3,7 @@
 namespace Laravel\Reverb\Protocols\Pusher;
 
 use Exception;
-use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Cache\RateLimiter;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
 use Laravel\Reverb\Contracts\Connection;
@@ -167,9 +167,10 @@ class Server
 
         $config = $connection->app()->rateLimiting();
 
+        $limiter = new RateLimiter(app('cache')->store('array'));
         $key = 'reverb:message:'.$connection->id();
 
-        if (RateLimiter::tooManyAttempts($key, $config['max_attempts'])) {
+        if ($limiter->tooManyAttempts($key, $config['max_attempts'])) {
             if ($config['terminate_on_limit'] ?? false) {
                 $connection->terminate();
             }
@@ -177,7 +178,7 @@ class Server
             throw new RateLimitExceeded;
         }
 
-        RateLimiter::increment($key, $config['decay_seconds'] ?? 1);
+        $limiter->increment($key, $config['decay_seconds'] ?? 1);
     }
 
     /**

--- a/tests/FakeConnection.php
+++ b/tests/FakeConnection.php
@@ -21,6 +21,11 @@ class FakeConnection extends BaseConnection
     public $messages = [];
 
     /**
+     * Whether the connection has been terminated.
+     */
+    public bool $wasTerminated = false;
+
+    /**
      * Connection identifier.
      */
     public string $identifier = '19c1c8e8-351b-4eb5-b6d9-6cbfc54a3446';
@@ -108,7 +113,7 @@ class FakeConnection extends BaseConnection
      */
     public function terminate(): void
     {
-        //
+        $this->wasTerminated = true;
     }
 
     /**
@@ -141,5 +146,13 @@ class FakeConnection extends BaseConnection
     public function assertHasBeenPinged(): void
     {
         Assert::assertTrue($this->hasBeenPinged);
+    }
+
+    /**
+     * Assert the connection has been terminated.
+     */
+    public function assertHasBeenTerminated(): void
+    {
+        Assert::assertTrue($this->wasTerminated);
     }
 }

--- a/tests/Unit/Protocols/Pusher/ServerTest.php
+++ b/tests/Unit/Protocols/Pusher/ServerTest.php
@@ -507,6 +507,98 @@ it('sends an error if something fails for channel type', function () {
     ]);
 });
 
+it('rejects a message when the rate limit is exceeded', function () {
+    $this->app['config']->set('reverb.apps.apps.0.rate_limiting', [
+        'enabled' => true,
+        'max_attempts' => 3,
+        'decay_seconds' => 1,
+        'terminate_on_limit' => false,
+    ]);
+
+    $this->server->open($connection = new FakeConnection);
+
+    for ($i = 0; $i < 3; $i++) {
+        $this->server->message(
+            $connection,
+            json_encode([
+                'event' => 'pusher:subscribe',
+                'data' => ['channel' => 'test-channel-'.$i],
+            ])
+        );
+    }
+
+    $this->server->message(
+        $connection,
+        json_encode([
+            'event' => 'pusher:subscribe',
+            'data' => ['channel' => 'test-channel-overflow'],
+        ])
+    );
+
+    $connection->assertReceived([
+        'event' => 'pusher:error',
+        'data' => json_encode([
+            'code' => 4301,
+            'message' => 'Rate limit exceeded',
+        ]),
+    ]);
+
+    expect($connection->wasTerminated)->toBeFalse();
+});
+
+it('terminates the connection when rate limit is exceeded and configured to terminate', function () {
+    $this->app['config']->set('reverb.apps.apps.0.rate_limiting', [
+        'enabled' => true,
+        'max_attempts' => 1,
+        'decay_seconds' => 1,
+        'terminate_on_limit' => true,
+    ]);
+
+    $this->server->open($connection = new FakeConnection);
+
+    $this->server->message(
+        $connection,
+        json_encode([
+            'event' => 'pusher:subscribe',
+            'data' => ['channel' => 'test-channel'],
+        ])
+    );
+
+    $this->server->message(
+        $connection,
+        json_encode([
+            'event' => 'pusher:subscribe',
+            'data' => ['channel' => 'test-channel-2'],
+        ])
+    );
+
+    $connection->assertReceived([
+        'event' => 'pusher:error',
+        'data' => json_encode([
+            'code' => 4301,
+            'message' => 'Rate limit exceeded',
+        ]),
+    ]);
+
+    expect($connection->wasTerminated)->toBeTrue();
+});
+
+it('allows unlimited messages when no rate limit is configured', function () {
+    $this->server->open($connection = new FakeConnection);
+
+    for ($i = 0; $i < 10; $i++) {
+        $this->server->message(
+            $connection,
+            json_encode([
+                'event' => 'pusher:subscribe',
+                'data' => ['channel' => 'test-channel-'.$i],
+            ])
+        );
+    }
+
+    $connection->assertReceivedCount(11);
+});
+
 it('allow receiving client event with empty data', function () {
     // Channel and app must exist for the server to process the message
     $channel = channels()->findOrCreate('private-chat.1');


### PR DESCRIPTION
Thanks for the inspiration from #326 and #370 this PR implements per application rate limiting.

It adds per app configuration options and leans on Laravel's rate limiter using the in-memory array cache to track attempts.

Thank you to @raphaelcangucu and @hamedelasma for the headstart. Would love if you could test this PR out and let me know if it addresses your needs.
