### PR TITLE
Use singletonIf and bindIf in makePusherRouter to prevent overwriting user-defined bindings

### DIFF
--- a/src/Servers/Reverb/Factory.php
+++ b/src/Servers/Reverb/Factory.php
@@ -70,17 +70,17 @@ class Factory
      */
     public static function makePusherRouter(string $path): Router
     {
-        app()->singleton(
+        app()->singletonIf(
             ChannelManager::class,
             fn () => new ArrayChannelManager
         );
 
-        app()->bind(
+        app()->bindIf(
             ChannelConnectionManager::class,
             fn () => new ArrayChannelConnectionManager
         );
 
-        app()->singleton(
+        app()->singletonIf(
             PubSubIncomingMessageHandler::class,
             fn () => new PusherPubSubIncomingMessageHandler,
         );


### PR DESCRIPTION
Closes [#372](https://github.com/laravel/reverb/issues/372)
## What this fixes

`Factory::makePusherRouter` unconditionally calls `singleton()` and `bind()` 
when registering its dependencies. This overwrites any custom implementations 
a user has already bound in their `AppServiceProvider`, with no way to prevent it.

## Changes

Replaced `singleton()` with `singletonIf()` and `bind()` with `bindIf()` for 
all three bindings in `makePusherRouter`:

- `ChannelManager`
- `ChannelConnectionManager`
- `PubSubIncomingMessageHandler`

## Benefit to end users

Users can now register their own implementations of these interfaces in their 
`AppServiceProvider` and have them respected when the Reverb server starts. 
Reverb's default implementations are used as a fallback only when no binding 
has already been registered.

## Does this break existing features?

No. If no custom binding is registered, `singletonIf()` and `bindIf()` behave 
identically to `singleton()` and `bind()`, so all existing behaviour is preserved.