### PR TITLE
Include server path in broadcasting connection config

### DIFF
--- a/src/Console/Commands/InstallCommand.php
+++ b/src/Console/Commands/InstallCommand.php
@@ -118,6 +118,7 @@ class InstallCommand extends Command
                             'port' => env('REVERB_PORT', 443),
                             'scheme' => env('REVERB_SCHEME', 'https'),
                             'useTLS' => env('REVERB_SCHEME', 'https') === 'https',
+                            'path' => env('REVERB_SERVER_PATH', ''),
                         ],
                         'client_options' => [
                             // Guzzle client options: https://docs.guzzlephp.org/en/stable/request-options.html


### PR DESCRIPTION
When `REVERB_SERVER_PATH` is set, Reverb prefixes all its routes with the configured path. But the broadcasting config generated by `reverb:install` doesn't pass this path to the Pusher SDK, so API requests go to `/apps/{id}/events` instead of `/{path}/apps/{id}/events`, returning 404.

This adds the `path` option to the generated Pusher SDK config so it matches the server's route prefix.

Fixes #361

Confirmed by @kamyweb in #369.