### PR TITLE
Use hash_equals for HTTP API signature verification

### DIFF
--- a/src/Protocols/Pusher/Http/Controllers/Controller.php
+++ b/src/Protocols/Pusher/Http/Controllers/Controller.php
@@ -110,7 +110,7 @@ abstract class Controller
         $signature = hash_hmac('sha256', $signature, $this->application->secret());
         $authSignature = $this->query['auth_signature'] ?? '';
 
-        if ($signature !== $authSignature) {
+        if (! hash_equals($signature, $authSignature)) {
             throw new HttpException(401, 'Authentication signature invalid.');
         }
     }


### PR DESCRIPTION
## Summary

Uses `hash_equals()` instead of `!==` for comparing HMAC signatures on HTTP API endpoints, providing constant-time comparison to mitigate timing attacks.

## Changes

The HTTP API controller at `Controller.php:113` compared HMAC signatures using `!==`, which is vulnerable to timing-based side-channel attacks. The WebSocket channel authentication in `InteractsWithPrivateChannels.php:32` already correctly uses `hash_equals()` for the same purpose. This change makes the HTTP API consistent with the WebSocket authentication.

## Test plan

- [x] Verify HTTP API authentication still works with valid signatures
- [x] Verify invalid signatures are still rejected
- [x] Confirm `InteractsWithPrivateChannels.php:32` already uses `hash_equals()` (consistency)