### PR TITLE
Fix TypeError crash from operator precedence in isWebSocketRequest()

### DIFF
--- a/src/Servers/Reverb/Http/Router.php
+++ b/src/Servers/Reverb/Http/Router.php
@@ -66,6 +66,12 @@ class Router
             return $controller($request, $wsConnection, ...Arr::except($route, ['_controller', '_route']));
         }
 
+        if ($this->requiresWebSocketUpgrade($controller)) {
+            $this->close($connection, 426, 'Upgrade required.', ['Upgrade' => 'websocket']);
+
+            return null;
+        }
+
         $routeParameters = Arr::except($route, [
             '_controller',
             '_route',
@@ -95,7 +101,23 @@ class Router
      */
     protected function isWebSocketRequest(RequestInterface $request): bool
     {
-        return $request->getHeader('Upgrade')[0] ?? null === 'websocket';
+        return ($request->getHeader('Upgrade')[0] ?? null) === 'websocket';
+    }
+
+    /**
+     * Determine whether the controller requires a WebSocket connection.
+     */
+    protected function requiresWebSocketUpgrade(callable $controller): bool
+    {
+        $parameters = $this->parameters($controller);
+
+        foreach ($parameters as $parameter) {
+            if ($parameter['type'] === ReverbConnection::class) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
## Summary

- Fixes operator precedence bug where `?? null === 'websocket'` always evaluated incorrectly due to `===` binding tighter than `??`, causing a TypeError crash when non-WebSocket HTTP requests hit WebSocket-only controllers
- Adds a `requiresWebSocketUpgrade()` guard that returns `426 Upgrade Required` for plain HTTP requests targeting WebSocket controllers
- Addresses #344

## Test plan

- [ ] Verify WebSocket connections still upgrade and connect normally
- [ ] Send a plain HTTP GET/POST to a WebSocket endpoint and confirm a 426 response instead of a TypeError
- [ ] Run existing test suite to check for regressions