### PR TITLE
Fix presence channel member lists when scaling with Redis

### DIFF
--- a/src/Protocols/Pusher/Channels/Concerns/InteractsWithPresenceChannels.php
+++ b/src/Protocols/Pusher/Channels/Concerns/InteractsWithPresenceChannels.php
@@ -3,6 +3,8 @@
 namespace Laravel\Reverb\Protocols\Pusher\Channels\Concerns;
 
 use Laravel\Reverb\Contracts\Connection;
+use Laravel\Reverb\Protocols\Pusher\EventDispatcher;
+use Laravel\Reverb\ServerProviderManager;
 
 trait InteractsWithPresenceChannels
 {
@@ -25,14 +27,17 @@ trait InteractsWithPresenceChannels
 
         parent::subscribe($connection, $auth, $data);
 
-        parent::broadcastInternally(
-            [
-                'event' => 'pusher_internal:member_added',
-                'data' => json_encode((object) $userData),
-                'channel' => $this->name(),
-            ],
-            $connection
-        );
+        $payload = [
+            'event' => 'pusher_internal:member_added',
+            'data' => json_encode((object) $userData),
+            'channel' => $this->name(),
+        ];
+
+        if ($this->scalingEnabled()) {
+            EventDispatcher::dispatch($connection->app(), $payload, $connection);
+        } else {
+            parent::broadcastInternally($payload, $connection);
+        }
     }
 
     /**
@@ -52,14 +57,17 @@ trait InteractsWithPresenceChannels
             return;
         }
 
-        parent::broadcast(
-            [
-                'event' => 'pusher_internal:member_removed',
-                'data' => json_encode(['user_id' => $subscription->data('user_id')]),
-                'channel' => $this->name(),
-            ],
-            $connection
-        );
+        $payload = [
+            'event' => 'pusher_internal:member_removed',
+            'data' => json_encode(['user_id' => $subscription->data('user_id')]),
+            'channel' => $this->name(),
+        ];
+
+        if ($this->scalingEnabled()) {
+            EventDispatcher::dispatch($connection->app(), $payload, $connection);
+        } else {
+            parent::broadcast($payload, $connection);
+        }
     }
 
     /**
@@ -85,7 +93,7 @@ trait InteractsWithPresenceChannels
             'presence' => [
                 'count' => $connections->count() ?? 0,
                 'ids' => $connections->map(fn ($connection) => $connection['user_id'])->values()->all(),
-                'hash' => $connections->keyBy('user_id')->map->user_info->toArray(),
+                'hash' => $connections->keyBy('user_id')->map(fn ($connection) => $connection['user_info'] ?? [])->toArray(),
             ],
         ];
     }
@@ -100,5 +108,13 @@ trait InteractsWithPresenceChannels
         }
 
         return collect($this->connections->all())->map(fn ($connection) => (string) $connection->data('user_id'))->contains($userId);
+    }
+
+    /**
+     * Determine if Redis scaling is enabled.
+     */
+    protected function scalingEnabled(): bool
+    {
+        return app(ServerProviderManager::class)->subscribesToEvents();
     }
 }

--- a/src/Protocols/Pusher/EventHandler.php
+++ b/src/Protocols/Pusher/EventHandler.php
@@ -8,7 +8,9 @@ use Illuminate\Support\Str;
 use Laravel\Reverb\Contracts\Connection;
 use Laravel\Reverb\Protocols\Pusher\Channels\CacheChannel;
 use Laravel\Reverb\Protocols\Pusher\Channels\Channel;
+use Laravel\Reverb\Protocols\Pusher\Channels\Concerns\InteractsWithPresenceChannels;
 use Laravel\Reverb\Protocols\Pusher\Contracts\ChannelManager;
+use Laravel\Reverb\ServerProviderManager;
 
 class EventHandler
 {
@@ -82,12 +84,26 @@ class EventHandler
      */
     protected function afterSubscribe(Channel $channel, Connection $connection): void
     {
-        $this->sendInternally($connection, 'subscription_succeeded', $channel->data(), $channel->name());
+        if ($this->isPresenceChannel($channel) && app(ServerProviderManager::class)->subscribesToEvents()) {
+            app(MetricsHandler::class)
+                ->gather($connection->app(), 'presence_data', ['channel' => $channel->name()])
+                ->then(fn ($data) => $this->sendInternally($connection, 'subscription_succeeded', $data, $channel->name()));
+        } else {
+            $this->sendInternally($connection, 'subscription_succeeded', $channel->data(), $channel->name());
+        }
 
         match (true) {
             $channel instanceof CacheChannel => $this->sendCachedPayload($channel, $connection),
             default => null,
         };
+    }
+
+    /**
+     * Determine if the given channel is a presence channel.
+     */
+    protected function isPresenceChannel(Channel $channel): bool
+    {
+        return in_array(InteractsWithPresenceChannels::class, class_uses($channel));
     }
 
     /**

--- a/src/Protocols/Pusher/MetricType.php
+++ b/src/Protocols/Pusher/MetricType.php
@@ -8,4 +8,5 @@ enum MetricType: string
     case CHANNEL = 'channel';
     case CHANNELS = 'channels';
     case CHANNEL_USERS = 'channel_users';
+    case PRESENCE_DATA = 'presence_data';
 }

--- a/src/Protocols/Pusher/MetricsHandler.php
+++ b/src/Protocols/Pusher/MetricsHandler.php
@@ -62,6 +62,7 @@ class MetricsHandler
             MetricType::CHANNELS => $this->channels($metric),
             MetricType::CHANNEL_USERS => $this->channelUsers($metric),
             MetricType::CONNECTIONS => $this->connections($metric),
+            MetricType::PRESENCE_DATA => $this->presenceData($metric),
             default => [],
         };
     }
@@ -118,6 +119,26 @@ class MetricsHandler
     }
 
     /**
+     * Get the presence data for the given application and channel.
+     */
+    protected function presenceData(PendingMetric $metric): array
+    {
+        $channel = $this->channels->for($metric->application())->find($metric->option('channel'));
+
+        if (! $channel) {
+            return [
+                'presence' => [
+                    'count' => 0,
+                    'ids' => [],
+                    'hash' => [],
+                ],
+            ];
+        }
+
+        return $channel->data();
+    }
+
+    /**
      * Get the connections for the given application.
      */
     protected function connections(PendingMetric $metric): array
@@ -168,7 +189,8 @@ class MetricsHandler
             MetricType::CONNECTIONS => array_reduce($metrics, fn ($carry, $item) => array_merge($carry, $item), []),
             MetricType::CHANNELS => $this->mergeChannels($metrics),
             MetricType::CHANNEL => $this->mergeChannel($metrics),
-            MetricType::CHANNEL_USERS => collect($metrics)->flatten(1)->unique()->all(),
+            MetricType::CHANNEL_USERS => collect($metrics)->flatten(1)->unique('id')->values()->all(),
+            MetricType::PRESENCE_DATA => $this->mergePresenceData($metrics),
             default => [],
         };
     }
@@ -209,6 +231,35 @@ class MetricsHandler
             }, collect())
             ->map(fn ($metrics) => $this->mergeChannel($metrics))
             ->all();
+    }
+
+    /**
+     * Merge multiple presence data sets into a single result set.
+     */
+    protected function mergePresenceData(array $metrics): array
+    {
+        $members = collect($metrics)
+            ->map(fn ($data) => $data['presence'] ?? [])
+            ->reduce(function ($carry, $presence) {
+                $ids = $presence['ids'] ?? [];
+                $hash = $presence['hash'] ?? [];
+
+                foreach ($ids as $id) {
+                    if (! $carry->has($id)) {
+                        $carry->put($id, $hash[$id] ?? []);
+                    }
+                }
+
+                return $carry;
+            }, collect());
+
+        return [
+            'presence' => [
+                'count' => $members->count(),
+                'ids' => $members->keys()->values()->all(),
+                'hash' => $members->all(),
+            ],
+        ];
     }
 
     /**


### PR DESCRIPTION
## Summary

- Routes presence channel `member_added` and `member_removed` events through `EventDispatcher` when Redis scaling is enabled, so all servers receive membership updates
- Adds a `presence_data` metric type with cross-server aggregation via `mergePresenceData()`, ensuring `subscription_succeeded` returns the full member list from all nodes
- Fixes the `->map->user_info` higher-order proxy that broke on raw arrays by using an explicit closure
- Deduplicates `channel_users` results by `id` when merging across subscribers
- Addresses #273

## Test plan

- [ ] With Redis scaling enabled, subscribe to a presence channel from two different Reverb servers and verify both see the complete member list
- [ ] Verify `member_added` and `member_removed` events propagate across servers
- [ ] Test single-server mode still works correctly (no Redis)
- [ ] Run existing test suite