### PR TITLE
[1.x] perf(pusher): drop O(N²) connections() merge from pubsub hot path

### DIFF
--- a/src/Protocols/Pusher/Contracts/ChannelManager.php
+++ b/src/Protocols/Pusher/Contracts/ChannelManager.php
@@ -49,6 +49,11 @@ interface ChannelManager
     public function connections(?string $channel = null): array;
 
     /**
+     * Find a single connection by its socket id.
+     */
+    public function findConnection(string $socketId): ?ChannelConnection;
+
+    /**
      * Unsubscribe from all channels.
      */
     public function unsubscribeFromAll(Connection $connection): void;

--- a/src/Protocols/Pusher/Managers/ArrayChannelManager.php
+++ b/src/Protocols/Pusher/Managers/ArrayChannelManager.php
@@ -93,12 +93,8 @@ class ArrayChannelManager implements ChannelManagerInterface
     {
         $channels = Arr::wrap($this->channels($channel));
 
-        // Avoid array_reduce + `+`: the `+` operator always returns a new
-        // array, forcing zend_array_dup of the accumulator on every step
-        // (O(N²) over total connections). `+=` mutates in place when the
-        // hash table is uniquely owned, dropping the dominant CPU cost on
-        // the WebSocket pubsub hot path under load.
         $result = [];
+
         foreach ($channels as $ch) {
             $result += $ch->connections();
         }

--- a/src/Protocols/Pusher/Managers/ArrayChannelManager.php
+++ b/src/Protocols/Pusher/Managers/ArrayChannelManager.php
@@ -103,7 +103,7 @@ class ArrayChannelManager implements ChannelManagerInterface
     }
 
     /**
-     * Find a single connection by socket id without flattening every channel.
+     * Find a single connection by socket ID.
      */
     public function findConnection(string $socketId): ?ChannelConnection
     {

--- a/src/Protocols/Pusher/Managers/ArrayChannelManager.php
+++ b/src/Protocols/Pusher/Managers/ArrayChannelManager.php
@@ -93,9 +93,31 @@ class ArrayChannelManager implements ChannelManagerInterface
     {
         $channels = Arr::wrap($this->channels($channel));
 
-        return array_reduce($channels, function ($carry, $channel) {
-            return $carry + $channel->connections();
-        }, []);
+        // Avoid array_reduce + `+`: the `+` operator always returns a new
+        // array, forcing zend_array_dup of the accumulator on every step
+        // (O(N²) over total connections). `+=` mutates in place when the
+        // hash table is uniquely owned, dropping the dominant CPU cost on
+        // the WebSocket pubsub hot path under load.
+        $result = [];
+        foreach ($channels as $ch) {
+            $result += $ch->connections();
+        }
+
+        return $result;
+    }
+
+    /**
+     * Find a single connection by socket id without flattening every channel.
+     */
+    public function findConnection(string $socketId): ?ChannelConnection
+    {
+        foreach ($this->channels() as $channel) {
+            if ($connection = $channel->connections()[$socketId] ?? null) {
+                return $connection;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/src/Protocols/Pusher/PusherPubSubIncomingMessageHandler.php
+++ b/src/Protocols/Pusher/PusherPubSubIncomingMessageHandler.php
@@ -22,7 +22,7 @@ class PusherPubSubIncomingMessageHandler implements PubSubIncomingMessageHandler
         $application = unserialize($event['application'] ?? null, ['allowed_classes' => [Application::class]]);
 
         $except = isset($event['socket_id']) ?
-            app(ChannelManager::class)->for($application)->connections()[$event['socket_id']] ?? null
+            app(ChannelManager::class)->for($application)->findConnection($event['socket_id'])
             : null;
 
         match ($event['type'] ?? null) {

--- a/tests/Unit/Protocols/Pusher/Managers/ChannelManagerTest.php
+++ b/tests/Unit/Protocols/Pusher/Managers/ChannelManagerTest.php
@@ -76,6 +76,29 @@ it('can get the data for a connection subscribed to a channel', function () {
     });
 });
 
+it('can find a connection by socket id without flattening every channel', function () {
+    $connections = collect(factory(3));
+
+    $channelOne = $this->channelManager->findOrCreate('test-channel-0');
+    $channelTwo = $this->channelManager->findOrCreate('test-channel-1');
+
+    $connections->each(function ($connection) use ($channelOne, $channelTwo) {
+        $channelOne->subscribe($connection->connection());
+        $channelTwo->subscribe($connection->connection());
+    });
+
+    $target = $connections->first()->connection();
+
+    $found = $this->channelManager->findConnection($target->id());
+
+    expect($found)->not->toBeNull();
+    expect($found->id())->toBe($target->id());
+});
+
+it('returns null from findConnection when the socket id is unknown', function () {
+    expect($this->channelManager->findConnection('does-not-exist'))->toBeNull();
+});
+
 it('can get all connections for all channels', function () {
     $connections = factory(12);
 


### PR DESCRIPTION
### Problem

Every Redis pubsub message goes through `PusherPubSubIncomingMessageHandler::handle()`, which asks the channel manager to flatten every channel into a single connection map just to look up one connection by socket id (the "except" client for the broadcast):

```php
$except = isset($event['socket_id'])
    ? app(ChannelManager::class)->for($application)->connections()[$event['socket_id']] ?? null
    : null;
```

`ArrayChannelManager::connections()` does that flatten via `array_reduce` with the `+` operator:

```php
return array_reduce($channels, function ($carry, $channel) {
    return $carry + $channel->connections();
}, []);
```

PHP's `+` on arrays always returns a new array, so each iteration triggers `zend_array_dup` of the accumulator. Across N channels with K connections each that becomes O(N²) over total connections — and it runs once per pubsub message on the single-threaded ReactPHP loop.

### Profiling evidence

Profiling a Reverb pod under load (a few hundred active channels, a few thousand pubsub messages/s across the fleet) with `perf` showed:

| | % CPU |
|---|---|
| `zend_array_dup` | 47.0% |
| `zend_array_destroy` | 30.5% |
| `zend_hash_merge` | 4.2% |
| message handler itself | <1% |

`phpspy` confirmed the dominant call stack was:

```
ArrayChannelManager::{closure}                ← line 95 (array_reduce callback)
  array_reduce
    ArrayChannelManager::connections          ← line 91
      PusherPubSubIncomingMessageHandler::handle
```

After applying this patch the same pod sees those Zend symbols disappear from the top of the profile (top is now `zend_hash_find` ~17%, `[JIT]` ~15%, normal distribution), and the new `findConnection` path accounts for ~0.1% of samples. Average per-pod CPU dropped roughly in half at the same connection load, and the HPA — previously pinned at max replicas — started downscaling immediately.

### Changes

1. **`ArrayChannelManager::connections()`**: replace `array_reduce + +` with `foreach + +=`. The `+=` operator mutates the hash table in place when uniquely owned, dropping the per-step dup. This makes the method O(total connections) instead of O(N²).

2. **New `ChannelManager::findConnection(string $socketId): ?ChannelConnection`**: returns the matching connection without ever building the merged map. `PusherPubSubIncomingMessageHandler::handle` uses it for the `$except` lookup.

3. Tests added for both findConnection paths (hit + miss); the existing `connections()` test still passes unchanged.

### Notes

- The `connections()` change alone is enough to drop the dup, but `findConnection` removes the merged-map allocation entirely on the hottest path. Both changes are kept because the `connections()` method is also called elsewhere (e.g. the `terminate` event handler in the same file iterates the full connection set).
- The interface change is additive; only `ArrayChannelManager` implements `ChannelManager` upstream, so no other implementations need updating.