### PR TITLE
Use timing-safe comparison for Pusher HTTP API signature check

### DIFF
--- a/src/Protocols/Pusher/Http/Controllers/Controller.php
+++ b/src/Protocols/Pusher/Http/Controllers/Controller.php
@@ -110,7 +110,7 @@ abstract class Controller
         $signature = hash_hmac('sha256', $signature, $this->application->secret());
         $authSignature = $this->query['auth_signature'] ?? '';
 
-        if (! hash_equals($signature, $authSignature)) {
+        if (! is_string($authSignature) || ! hash_equals($signature, $authSignature)) {
             throw new HttpException(401, 'Authentication signature invalid.');
         }
     }

--- a/src/Protocols/Pusher/Http/Controllers/Controller.php
+++ b/src/Protocols/Pusher/Http/Controllers/Controller.php
@@ -110,7 +110,7 @@ abstract class Controller
         $signature = hash_hmac('sha256', $signature, $this->application->secret());
         $authSignature = $this->query['auth_signature'] ?? '';
 
-        if ($signature !== $authSignature) {
+        if (! hash_equals($signature, $authSignature)) {
             throw new HttpException(401, 'Authentication signature invalid.');
         }
     }


### PR DESCRIPTION
The Pusher HTTP API signature verifier compared the freshly-computed HMAC-SHA256 against the attacker-supplied `auth_signature` with PHP's strict-inequality operator, which short-circuits on the first non-matching byte. Cryptographic comparisons should be constant-time; the WebSocket private/presence channel verifier in this repo already uses `hash_equals()`, so the HTTP path was an inconsistency.
