### PR TITLE
Carry socket id through pub/sub so toOthers works across servers

### DIFF
--- a/src/Protocols/Pusher/EventDispatcher.php
+++ b/src/Protocols/Pusher/EventDispatcher.php
@@ -14,7 +14,7 @@ class EventDispatcher
     /**
      * Dispatch a message to a channel.
      */
-    public static function dispatch(Application $app, array $payload, ?Connection $connection = null): void
+    public static function dispatch(Application $app, array $payload, ?Connection $connection = null, ?string $socketId = null): void
     {
         $server = app(ServerProviderManager::class);
 
@@ -30,8 +30,10 @@ class EventDispatcher
             'payload' => $payload,
         ];
 
-        if ($connection?->id() !== null) {
-            $data['socket_id'] = $connection?->id();
+        $socketId ??= $connection?->id();
+
+        if ($socketId !== null) {
+            $data['socket_id'] = $socketId;
         }
 
         app(PubSubProvider::class)->publish($data);

--- a/src/Protocols/Pusher/Http/Controllers/EventsBatchController.php
+++ b/src/Protocols/Pusher/Http/Controllers/EventsBatchController.php
@@ -43,7 +43,8 @@ class EventsBatchController extends Controller
                     'channel' => $item['channel'],
                     'data' => $item['data'],
                 ],
-                isset($item['socket_id']) ? ($this->channels->connections()[$item['socket_id']] ?? null) : null
+                isset($item['socket_id']) ? ($this->channels->connections()[$item['socket_id']] ?? null) : null,
+                $item['socket_id'] ?? null,
             );
 
             return isset($item['info']) ? app(MetricsHandler::class)->gather(

--- a/src/Protocols/Pusher/Http/Controllers/EventsBatchController.php
+++ b/src/Protocols/Pusher/Http/Controllers/EventsBatchController.php
@@ -36,6 +36,8 @@ class EventsBatchController extends Controller
         $items = collect($payload['batch']);
 
         $items = $items->map(function ($item) {
+            $except = isset($item['socket_id']) ? ($this->channels->connections()[$item['socket_id']] ?? null) : null;
+
             EventDispatcher::dispatch(
                 $this->application,
                 [
@@ -43,7 +45,7 @@ class EventsBatchController extends Controller
                     'channel' => $item['channel'],
                     'data' => $item['data'],
                 ],
-                isset($item['socket_id']) ? ($this->channels->connections()[$item['socket_id']] ?? null) : null,
+                $except ? $except->connection() : null,
                 $item['socket_id'] ?? null,
             );
 

--- a/src/Protocols/Pusher/Http/Controllers/EventsController.php
+++ b/src/Protocols/Pusher/Http/Controllers/EventsController.php
@@ -44,7 +44,8 @@ class EventsController extends Controller
                 'channels' => $channels,
                 'data' => $payload['data'],
             ],
-            $except ? $except->connection() : null
+            $except ? $except->connection() : null,
+            $payload['socket_id'] ?? null,
         );
 
         if (isset($payload['info'])) {

--- a/tests/Feature/Protocols/Pusher/Reverb/EventsBatchControllerTest.php
+++ b/tests/Feature/Protocols/Pusher/Reverb/EventsBatchControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Laravel\Reverb\ServerProviderManager;
+use Laravel\Reverb\Servers\Reverb\Contracts\PubSubProvider;
 use Laravel\Reverb\Tests\ReverbTestCase;
 use React\Http\Message\ResponseException;
 
@@ -99,6 +101,23 @@ it('can send the content-length header', function () {
     expect($response->getHeader('Content-Length'))->toBe(['12']);
 });
 
+it('does not fail when ignoring a local subscriber in a batch event', function () {
+    $connection = connect();
+    subscribe('test-channel-two', connection: $connection);
+
+    $response = await($this->signedPostRequest('batch_events', ['batch' => [
+        [
+            'name' => 'NewEvent',
+            'channel' => 'test-channel-two',
+            'data' => json_encode(['some' => 'data']),
+            'socket_id' => $connection->socketId(),
+        ],
+    ]]));
+
+    expect($response->getStatusCode())->toBe(200);
+    expect($response->getBody()->getContents())->toBe('{"batch":{}}');
+});
+
 it('can receive an event batch trigger with multiple events and gather info for each', function () {
     $this->usingRedis();
 
@@ -150,6 +169,33 @@ it('can receive an event batch trigger with multiple events and gather info for 
 
     expect($response->getStatusCode())->toBe(200);
     expect($response->getBody()->getContents())->toBe('{"batch":[{"user_count":1},{}]}');
+});
+
+it('publishes the originating socket id for a batch event over redis even when the connection is not local', function () {
+    $published = null;
+
+    $provider = Mockery::mock(PubSubProvider::class)->shouldIgnoreMissing();
+    $provider->shouldReceive('publish')
+        ->once()
+        ->with(Mockery::on(function ($payload) use (&$published) {
+            $published = $payload;
+
+            return true;
+        }));
+
+    $this->app->instance(PubSubProvider::class, $provider);
+    app(ServerProviderManager::class)->withPublishing();
+
+    $response = await($this->signedPostRequest('batch_events', ['batch' => [[
+        'name' => 'NewEvent',
+        'channel' => 'test-channel',
+        'data' => json_encode(['some' => 'data']),
+        'socket_id' => '1234.5678',
+    ]]]));
+
+    expect($response->getStatusCode())->toBe(200);
+    expect($published)->not->toBeNull();
+    expect($published['socket_id'] ?? null)->toBe('1234.5678');
 });
 
 it('fails when payload is invalid', function () {

--- a/tests/Feature/Protocols/Pusher/Reverb/EventsControllerTest.php
+++ b/tests/Feature/Protocols/Pusher/Reverb/EventsControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Laravel\Reverb\ServerProviderManager;
+use Laravel\Reverb\Servers\Reverb\Contracts\PubSubProvider;
 use Laravel\Reverb\Tests\ReverbTestCase;
 use React\Http\Browser;
 use React\Http\Message\ResponseException;
@@ -100,6 +102,33 @@ it('can ignore a subscriber when publishing events over redis', function () {
     $connection->assertReceived('{"event":"NewEvent","data":"{\"some\":\"data\"}","channel":"test-channel-two"}', 1);
     expect($response->getStatusCode())->toBe(200);
     expect($response->getBody()->getContents())->toBe('{}');
+});
+
+it('publishes the originating socket id over redis even when the connection is not local', function () {
+    $published = null;
+
+    $provider = Mockery::mock(PubSubProvider::class)->shouldIgnoreMissing();
+    $provider->shouldReceive('publish')
+        ->once()
+        ->with(Mockery::on(function ($payload) use (&$published) {
+            $published = $payload;
+
+            return true;
+        }));
+
+    $this->app->instance(PubSubProvider::class, $provider);
+    app(ServerProviderManager::class)->withPublishing();
+
+    $response = await($this->signedPostRequest('events', [
+        'name' => 'NewEvent',
+        'channel' => 'test-channel',
+        'data' => json_encode(['some' => 'data']),
+        'socket_id' => '1234.5678', // not connected to this server
+    ]));
+
+    expect($response->getStatusCode())->toBe(200);
+    expect($published)->not->toBeNull();
+    expect($published['socket_id'] ?? null)->toBe('1234.5678');
 });
 
 it('does not fail when ignoring an invalid subscriber', function () {


### PR DESCRIPTION
When scaling is enabled, EventsController resolves the excepted connection from the *local* connection list before publishing. If the publishing server does not hold the originating connection (multiple servers behind a load balancer), that connection is null and the socket id was dropped from the Redis payload, so the server that *does* hold it could not exclude it — ->toOthers() silently failed across the scaling boundary (~50% of the time with two servers).

dispatch() now accepts an optional socket id string alongside the Connection, and the controllers pass it through. The id is published to the bus regardless of whether the connection is resolvable locally; each subscribing server resolves and excludes it locally (unchanged).

Backwards compatible: the Connection parameter and dispatchSynchronously are untouched; the new parameter is optional and falls back to the connection's id, so existing callers behave identically.