### PR TITLE
Add `registerDevCommands` helper

### DIFF
--- a/src/Reverb.php
+++ b/src/Reverb.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Laravel\Reverb;
+
+class Reverb
+{
+
+    /**
+     * Helper method to register the Reverb development server Artisan command when running in a local environment.
+     * Should be called from the `boot` method of an application service provider.
+     *
+     * @return void
+     */
+    public static function registerDevCommands(): void
+    {
+        if (class_exists(\Illuminate\Foundation\DevCommands::class)) {
+            \Illuminate\Foundation\DevCommands::artisan('reverb:start', 'reverb');
+        }
+    }
+}

--- a/src/Reverb.php
+++ b/src/Reverb.php
@@ -4,7 +4,6 @@ namespace Laravel\Reverb;
 
 class Reverb
 {
-
     /**
      * Helper method to register the Reverb development server Artisan command when running in a local environment.
      * Should be called from the `boot` method of an application service provider.

--- a/src/Reverb.php
+++ b/src/Reverb.php
@@ -5,8 +5,7 @@ namespace Laravel\Reverb;
 class Reverb
 {
     /**
-     * Helper method to register the Reverb development server Artisan command when running in a local environment.
-     * Should be called from the `boot` method of an application service provider.
+     * Register the Reverb dev commands.
      *
      * @return void
      */


### PR DESCRIPTION
Adds a `Reverb::registerDevCommands()` method so users can register `reverb:start` as a dev command for `php artisan dev`.