### PR TITLE
Auto register dev commands

### DIFF
--- a/src/ReverbServiceProvider.php
+++ b/src/ReverbServiceProvider.php
@@ -26,6 +26,8 @@ class ReverbServiceProvider extends ServiceProvider
         $this->app->singleton(ServerProviderManager::class);
 
         $this->app->make(ServerProviderManager::class)->register();
+
+        Reverb::registerDevCommands();
     }
 
     /**


### PR DESCRIPTION
Auto registers the `php artisan reverb:start` into DevCommands if the class exists.