### PR TITLE
Add doctor diagnostics

### DIFF
--- a/.github/workflows/spec-tests.yml
+++ b/.github/workflows/spec-tests.yml
@@ -46,6 +46,10 @@ jobs:
           tools: composer:v2
           coverage: none
 
+      - name: Remove incompatible dependencies
+        if: matrix.laravel < 12 || matrix.php < 8.3
+        run: composer remove laravel/doctor --dev --no-update --no-interaction
+
       - name: Install dependencies
         run: |
           composer update --prefer-dist --no-interaction --no-progress --with="illuminate/contracts=^${{ matrix.laravel }}"

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -12,4 +12,6 @@ permissions:
 
 jobs:
   tests:
-    uses: laravel/.github/.github/workflows/static-analysis.yml@9c15e86fffce728fb6c50ebeae24fd63e98f4d1d # main
+    uses: laravel/.github/.github/workflows/static-analysis.yml@41cb33d868e3f67ea2c9bb53f1ebd9a379400f63 # main
+    with:
+      php: "8.3"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,6 +57,10 @@ jobs:
           tools: composer:v2
           coverage: none
 
+      - name: Remove incompatible dependencies
+        if: matrix.laravel < 12 || matrix.php < 8.3
+        run: composer remove laravel/doctor --dev --no-update --no-interaction
+
       - name: Install dependencies
         run: |
           composer update --prefer-dist --no-interaction --no-progress --with="laravel/framework:^${{ matrix.laravel }}"

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "symfony/http-foundation": "^6.3|^7.0|^8.0"
     },
     "require-dev": {
+        "laravel/doctor": "^0.1",
         "orchestra/testbench": "^8.36|^9.15|^10.8|^11.0",
         "pestphp/pest": "^2.0|^3.0|^4.0",
         "phpstan/phpstan": "^1.10",

--- a/src/Diagnostics/ResolvesReverbConfiguration.php
+++ b/src/Diagnostics/ResolvesReverbConfiguration.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Laravel\Reverb\Diagnostics;
+
+use Laravel\Doctor\Support\Configured;
+
+trait ResolvesReverbConfiguration
+{
+    /**
+     * Get the active broadcast connection name when it uses Reverb.
+     */
+    private function reverbConnection(): ?string
+    {
+        $connection = Configured::string('broadcasting.default', 'null');
+        $driver = Configured::string("broadcasting.connections.{$connection}.driver", $connection);
+
+        return $driver === 'reverb' ? $connection : null;
+    }
+
+    /**
+     * Get the default Reverb server name.
+     */
+    private function defaultServer(): string
+    {
+        return Configured::string('reverb.default', 'reverb');
+    }
+
+    /**
+     * Get the default Reverb server's configuration.
+     *
+     * @return array<string, mixed>|null
+     */
+    private function defaultServerConfiguration(): ?array
+    {
+        $configuration = config("reverb.servers.{$this->defaultServer()}");
+
+        return is_array($configuration) && $configuration !== [] ? $configuration : null;
+    }
+
+    /**
+     * Find the first configured application with the given key.
+     *
+     * @return array<string, mixed>|null
+     */
+    private function applicationWithKey(?string $key): ?array
+    {
+        if ($key === null) {
+            return null;
+        }
+
+        foreach ((array) config('reverb.apps.apps') as $application) {
+            if (is_array($application) && (string) ($application['key'] ?? '') === $key) {
+                return $application;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Diagnostics/ReverbAllowedOriginsCoverAppUrl.php
+++ b/src/Diagnostics/ReverbAllowedOriginsCoverAppUrl.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Laravel\Reverb\Diagnostics;
+
+use Illuminate\Support\Str;
+use Laravel\Doctor\Diagnostic;
+use Laravel\Doctor\Results\DiagnosticResult;
+use Laravel\Doctor\Results\Link;
+use Laravel\Doctor\Results\Message;
+use Laravel\Doctor\Support\Configured;
+use Laravel\Doctor\Support\Details;
+
+class ReverbAllowedOriginsCoverAppUrl extends Diagnostic
+{
+    use ResolvesReverbConfiguration;
+
+    public string $name = 'Reverb allows the app origin';
+
+    public string $group = 'reverb';
+
+    /**
+     * Get the diagnostic's named message definitions.
+     *
+     * @return array<string, string|Message>
+     */
+    protected function messages(): array
+    {
+        return [
+            'not-used' => 'The active broadcast connection does not use Reverb.',
+            'not-config-provider' => 'Reverb applications are not managed by the config provider.',
+            'no-app' => 'No Reverb application matches the broadcast connection, so allowed origins were not checked.',
+            'no-app-url' => 'The application URL is not configured, so allowed origins were not checked.',
+            'no-origins' => Message::make(
+                summary: 'The Reverb application does not allow any origins.',
+                remediation: 'Add the application\'s host to `allowed_origins` in `reverb.apps.apps` so browser connections are not rejected.',
+            )->link(Link::docs('reverb', 'allowed-origins')),
+            'all-origins' => 'The Reverb application allows connections from any origin.',
+            'not-covered' => Message::make(
+                summary: 'The Reverb application\'s allowed origins do not include the application\'s own host.',
+                remediation: 'Add the host to `allowed_origins` in `reverb.apps.apps` so browser connections are not rejected.',
+            )->link(Link::docs('reverb', 'allowed-origins')),
+            'covered' => 'The Reverb application allows connections from the application\'s host.',
+        ];
+    }
+
+    /**
+     * Run the diagnostic.
+     */
+    public function check(): DiagnosticResult
+    {
+        $connection = $this->reverbConnection();
+
+        if ($connection === null) {
+            return $this->skip('not-used');
+        }
+
+        if (Configured::string('reverb.apps.provider') !== 'config') {
+            return $this->skip('not-config-provider');
+        }
+
+        $app = $this->applicationWithKey(
+            Configured::string("broadcasting.connections.{$connection}.key"),
+        );
+
+        if ($app === null) {
+            return $this->skip('no-app');
+        }
+
+        $origins = $app['allowed_origins'] ?? null;
+
+        if (! is_array($origins) || $origins === []) {
+            return $this->fail('no-origins');
+        }
+
+        if (in_array('*', $origins, true)) {
+            return $this->pass('all-origins');
+        }
+
+        $host = $this->applicationHost();
+
+        if ($host === null) {
+            return $this->skip('no-app-url');
+        }
+
+        $covered = collect($origins)->contains(
+            static fn ($origin): bool => is_string($origin) && Str::is($origin, $host),
+        );
+
+        if (! $covered) {
+            return $this->fail('not-covered')
+                ->withDetails(Details::bullets([$host]));
+        }
+
+        return $this->pass('covered');
+    }
+
+    /**
+     * Get the host browsers will send as the connection origin.
+     *
+     * Browsers originate connections from the frontend, so a configured
+     * frontend URL supersedes the application URL, which may be an API
+     * host that never opens browser connections.
+     */
+    private function applicationHost(): ?string
+    {
+        foreach (['app.frontend_url', 'app.url'] as $key) {
+            $url = Configured::string($key);
+            $host = $url === null ? null : parse_url($url, PHP_URL_HOST);
+
+            if (is_string($host) && $host !== '') {
+                return $host;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Diagnostics/ReverbAppsAreConfigured.php
+++ b/src/Diagnostics/ReverbAppsAreConfigured.php
@@ -1,0 +1,199 @@
+<?php
+
+namespace Laravel\Reverb\Diagnostics;
+
+use Illuminate\Support\Str;
+use Laravel\Doctor\Diagnostic;
+use Laravel\Doctor\Results\DiagnosticResult;
+use Laravel\Doctor\Results\Link;
+use Laravel\Doctor\Results\Message;
+use Laravel\Doctor\Support\Configured;
+use Laravel\Doctor\Support\Details;
+
+class ReverbAppsAreConfigured extends Diagnostic
+{
+    use ResolvesReverbConfiguration;
+
+    public string $name = 'Reverb apps are configured';
+
+    public string $group = 'reverb';
+
+    /**
+     * Get the diagnostic's named message definitions.
+     *
+     * @return array<string, string|Message>
+     */
+    protected function messages(): array
+    {
+        return [
+            'not-used' => 'The active broadcast connection does not use Reverb.',
+            'not-config-provider' => 'Reverb applications are not managed by the config provider.',
+            'not-configured' => 'The Reverb broadcast connection is missing required configuration.',
+            'no-apps' => Message::make(
+                summary: 'No Reverb applications are defined.',
+                remediation: 'Add an application with a key, secret, and app ID to `reverb.apps.apps`.',
+            )->link(Link::docs('reverb', 'application-credentials')),
+            'missing-credentials' => Message::make(
+                summary: 'Some Reverb applications are missing credentials.',
+                remediation: 'Set `REVERB_APP_ID`, `REVERB_APP_KEY`, and `REVERB_APP_SECRET` in the deployment environment.',
+            )->link(Link::docs('reverb', 'application-credentials')),
+            'missing-options' => Message::make(
+                summary: 'Some Reverb applications are missing options the server requires.',
+                remediation: 'Add `ping_interval`, `allowed_origins`, and `max_message_size` to every application in `reverb.apps.apps`.',
+            )->link(Link::docs('reverb', 'configuration')),
+            'duplicate-credentials' => Message::make(
+                summary: 'Multiple Reverb applications share the same key or app ID.',
+                remediation: 'Give every application in `reverb.apps.apps` a unique key and app ID so lookups resolve the intended application.',
+            )->link(Link::docs('reverb', 'additional-applications')),
+            'configured' => 'Every Reverb application has the credentials and options the server requires.',
+        ];
+    }
+
+    /**
+     * Run the diagnostic.
+     */
+    public function check(): DiagnosticResult
+    {
+        $connection = $this->reverbConnection();
+
+        if ($connection === null) {
+            return $this->skip('not-used');
+        }
+
+        if (Configured::string('reverb.apps.provider') !== 'config') {
+            return $this->skip('not-config-provider');
+        }
+
+        $apps = config('reverb.apps.apps');
+
+        if (! is_array($apps) || $apps === []) {
+            return $this->fail('no-apps');
+        }
+
+        $missing = $this->missingCredentials($apps);
+
+        if ($missing !== []) {
+            $unexplained = $this->withoutSharedEnvironmentCredentials($missing, $connection);
+
+            if ($unexplained === []) {
+                return $this->skip('not-configured');
+            }
+
+            return $this->fail('missing-credentials')
+                ->withDetails(Details::bullets($unexplained));
+        }
+
+        $missingOptions = $this->missingOptions($apps);
+
+        if ($missingOptions !== []) {
+            return $this->fail('missing-options')
+                ->withDetails(Details::bullets($missingOptions));
+        }
+
+        $duplicated = $this->duplicatedCredentials($apps);
+
+        if ($duplicated !== []) {
+            return $this->fail('duplicate-credentials')
+                ->withDetails(Details::bullets($duplicated));
+        }
+
+        return $this->pass('configured');
+    }
+
+    /**
+     * Get the configuration paths of credentials missing from any application.
+     *
+     * @param  array<int|string, mixed>  $apps
+     * @return list<string>
+     */
+    private function missingCredentials(array $apps): array
+    {
+        $missing = [];
+
+        foreach (array_keys($apps) as $index) {
+            $missing = [...$missing, ...Configured::missing([
+                "reverb.apps.apps.{$index}.app_id",
+                "reverb.apps.apps.{$index}.key",
+                "reverb.apps.apps.{$index}.secret",
+            ])];
+        }
+
+        return $missing;
+    }
+
+    /**
+     * Discard missing paths whose credential the broadcast connection also lacks.
+     *
+     * When both sides lack the same credential the root cause is the shared
+     * REVERB_APP_* environment variables, which ReverbConfigurationValuesAreSet
+     * reports.
+     *
+     * @param  list<string>  $missing
+     * @return list<string>
+     */
+    private function withoutSharedEnvironmentCredentials(array $missing, string $connection): array
+    {
+        $shared = array_map(
+            static fn (string $path): string => Str::afterLast($path, '.'),
+            Configured::missing([
+                "broadcasting.connections.{$connection}.app_id",
+                "broadcasting.connections.{$connection}.key",
+                "broadcasting.connections.{$connection}.secret",
+            ]),
+        );
+
+        return array_values(array_filter(
+            $missing,
+            static fn (string $path): bool => ! in_array(Str::afterLast($path, '.'), $shared, true),
+        ));
+    }
+
+    /**
+     * Get the paths of options the server reads without fallbacks but applications omit.
+     *
+     * ConfigApplicationProvider passes these to the Application constructor
+     * directly, so a missing key crashes application lookups at runtime.
+     *
+     * @param  array<int|string, mixed>  $apps
+     * @return list<string>
+     */
+    private function missingOptions(array $apps): array
+    {
+        $missing = [];
+
+        foreach ($apps as $index => $app) {
+            foreach (['ping_interval', 'allowed_origins', 'max_message_size'] as $option) {
+                if (! is_array($app) || ! array_key_exists($option, $app)) {
+                    $missing[] = "reverb.apps.apps.{$index}.{$option}";
+                }
+            }
+        }
+
+        return $missing;
+    }
+
+    /**
+     * Describe keys and app IDs shared by more than one application.
+     *
+     * @param  array<int|string, mixed>  $apps
+     * @return list<string>
+     */
+    private function duplicatedCredentials(array $apps): array
+    {
+        $duplicated = [];
+
+        foreach (['key', 'app_id'] as $credential) {
+            $counts = collect($apps)
+                ->map(fn ($app) => is_array($app) ? ($app[$credential] ?? null) : null)
+                ->filter(fn ($value): bool => is_scalar($value) && (string) $value !== '')
+                ->countBy(fn ($value): string => (string) $value)
+                ->filter(fn (int $count): bool => $count > 1);
+
+            foreach ($counts as $value => $count) {
+                $duplicated[] = sprintf('%s [%s] is used by %d applications', $credential, $value, $count);
+            }
+        }
+
+        return $duplicated;
+    }
+}

--- a/src/Diagnostics/ReverbBroadcasterCredentialsMatchApp.php
+++ b/src/Diagnostics/ReverbBroadcasterCredentialsMatchApp.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Laravel\Reverb\Diagnostics;
+
+use Laravel\Doctor\Diagnostic;
+use Laravel\Doctor\Results\DiagnosticResult;
+use Laravel\Doctor\Results\Link;
+use Laravel\Doctor\Results\Message;
+use Laravel\Doctor\Support\Configured;
+use Laravel\Doctor\Support\Details;
+
+class ReverbBroadcasterCredentialsMatchApp extends Diagnostic
+{
+    use ResolvesReverbConfiguration;
+
+    public string $name = 'Reverb broadcaster credentials match an app';
+
+    public string $group = 'reverb';
+
+    /**
+     * Get the diagnostic's named message definitions.
+     *
+     * @return array<string, string|Message>
+     */
+    protected function messages(): array
+    {
+        return [
+            'not-used' => 'The active broadcast connection does not use Reverb.',
+            'not-config-provider' => 'Reverb applications are not managed by the config provider.',
+            'not-configured' => 'The Reverb broadcast connection is missing required configuration.',
+            'unknown-key' => Message::make(
+                summary: 'No Reverb application matches the broadcast connection\'s key.',
+                remediation: 'Set the broadcast connection and the `reverb.apps.apps` entry to the same `REVERB_APP_KEY`.',
+            )->link(Link::docs('reverb', 'application-credentials')),
+            'mismatched' => Message::make(
+                summary: 'The Reverb application matching the broadcast connection\'s key has different credentials.',
+                remediation: 'Align the app ID and secret between the broadcast connection and `reverb.apps.apps`.',
+            )->link(Link::docs('reverb', 'application-credentials')),
+            'matched' => 'The broadcast connection credentials match a Reverb application.',
+        ];
+    }
+
+    /**
+     * Run the diagnostic.
+     */
+    public function check(): DiagnosticResult
+    {
+        $connection = $this->reverbConnection();
+
+        if ($connection === null) {
+            return $this->skip('not-used');
+        }
+
+        if (Configured::string('reverb.apps.provider') !== 'config') {
+            return $this->skip('not-config-provider');
+        }
+
+        $prefix = "broadcasting.connections.{$connection}";
+
+        $key = Configured::string("{$prefix}.key");
+        $secret = Configured::string("{$prefix}.secret");
+        $appId = Configured::string("{$prefix}.app_id");
+
+        if ($key === null || $secret === null || $appId === null) {
+            return $this->skip('not-configured');
+        }
+
+        $app = $this->applicationWithKey($key);
+
+        if ($app === null) {
+            return $this->fail('unknown-key');
+        }
+
+        $mismatched = array_values(array_filter([
+            (string) ($app['app_id'] ?? '') === $appId ? null : 'app_id',
+            (string) ($app['secret'] ?? '') === $secret ? null : 'secret',
+        ]));
+
+        if ($mismatched !== []) {
+            return $this->fail('mismatched')
+                ->withDetails(Details::bullets(array_map(
+                    static fn (string $credential): string => "The application's {$credential} does not match the broadcast connection.",
+                    $mismatched,
+                )));
+        }
+
+        return $this->pass('matched');
+    }
+}

--- a/src/Diagnostics/ReverbConfigurationValuesAreSet.php
+++ b/src/Diagnostics/ReverbConfigurationValuesAreSet.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Laravel\Reverb\Diagnostics;
+
+use Laravel\Doctor\Diagnostic;
+use Laravel\Doctor\Results\DiagnosticResult;
+use Laravel\Doctor\Results\Link;
+use Laravel\Doctor\Results\Message;
+use Laravel\Doctor\Support\Configured;
+use Laravel\Doctor\Support\Details;
+
+class ReverbConfigurationValuesAreSet extends Diagnostic
+{
+    use ResolvesReverbConfiguration;
+
+    public string $name = 'Reverb config values are set';
+
+    public string $group = 'reverb';
+
+    /**
+     * Get the diagnostic's named message definitions.
+     *
+     * @return array<string, string|Message>
+     */
+    protected function messages(): array
+    {
+        return [
+            'not-used' => 'The active broadcast connection does not use Reverb.',
+            'set' => 'Every configuration value required by the active Reverb broadcast connection is set.',
+            'missing' => Message::make(
+                summary: 'Some configuration values required by the active Reverb broadcast connection are not set.',
+                remediation: 'Set the missing values, typically by defining their environment variables in .env or the deployment environment.',
+            )->link(Link::docs('reverb', 'configuration')),
+        ];
+    }
+
+    /**
+     * Run the diagnostic.
+     */
+    public function check(): DiagnosticResult
+    {
+        $connection = $this->reverbConnection();
+
+        if ($connection === null) {
+            return $this->skip('not-used');
+        }
+
+        $prefix = "broadcasting.connections.{$connection}";
+
+        $missing = Configured::missing([
+            "{$prefix}.app_id",
+            "{$prefix}.key",
+            "{$prefix}.secret",
+            "{$prefix}.options.host",
+        ]);
+
+        if ($missing === []) {
+            return $this->pass('set');
+        }
+
+        return $this->fail('missing')
+            ->withDetails(Details::bullets($missing));
+    }
+}

--- a/src/Diagnostics/ReverbConnectionIsReachable.php
+++ b/src/Diagnostics/ReverbConnectionIsReachable.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Laravel\Reverb\Diagnostics;
+
+use Illuminate\Broadcasting\BroadcastManager;
+use Laravel\Doctor\Diagnostic;
+use Laravel\Doctor\Results\DiagnosticResult;
+use Laravel\Doctor\Results\Link;
+use Laravel\Doctor\Results\Message;
+use Laravel\Doctor\Support\Configured;
+use RuntimeException;
+use Throwable;
+
+class ReverbConnectionIsReachable extends Diagnostic
+{
+    use ResolvesReverbConfiguration;
+
+    public string $name = 'Reverb connects';
+
+    public string $group = 'reverb';
+
+    /**
+     * Get the diagnostic's named message definitions.
+     *
+     * @return array<string, string|Message>
+     */
+    protected function messages(): array
+    {
+        return [
+            'not-used' => 'The active broadcast connection does not use Reverb.',
+            'not-configured' => 'The Reverb broadcast connection is missing required configuration.',
+            'unreachable' => Message::make(
+                summary: 'The application cannot connect to Reverb using broadcast connection [{connection}].',
+                remediation: 'Check the Reverb public host, port, scheme, path, app credentials, and server process.',
+            )->link(Link::docs('reverb', 'running-server')),
+            'reachable' => 'The application can connect to Reverb using broadcast connection [{connection}].',
+        ];
+    }
+
+    /**
+     * Run the diagnostic.
+     */
+    public function check(): DiagnosticResult
+    {
+        $connection = $this->reverbConnection();
+
+        if ($connection === null) {
+            return $this->skip('not-used');
+        }
+
+        $prefix = "broadcasting.connections.{$connection}";
+
+        $missing = Configured::missing([
+            "{$prefix}.app_id",
+            "{$prefix}.key",
+            "{$prefix}.secret",
+            "{$prefix}.options.host",
+        ]);
+
+        if ($missing !== []) {
+            return $this->skip('not-configured');
+        }
+
+        /** @var array<string, mixed> $configuration */
+        $configuration = config($prefix);
+        $options = $configuration['options'] ?? [];
+        $clientOptions = $configuration['client_options'] ?? [];
+
+        $configuration['options'] = [
+            ...(is_array($options) ? $options : []),
+            'timeout' => 2,
+        ];
+
+        $configuration['client_options'] = [
+            ...(is_array($clientOptions) ? $clientOptions : []),
+            'connect_timeout' => 2,
+            'timeout' => 2,
+        ];
+
+        try {
+            $response = app(BroadcastManager::class)->pusher($configuration)->get('/channels');
+
+            if (! is_object($response) || ! property_exists($response, 'channels')) {
+                throw new RuntimeException('The Reverb channels endpoint returned an unexpected response.');
+            }
+        } catch (Throwable $e) {
+            return $this->fail('unreachable', ['connection' => $connection])
+                ->withDetails($e->getMessage());
+        }
+
+        return $this->pass('reachable', ['connection' => $connection]);
+    }
+}

--- a/src/Diagnostics/ReverbDefaultServerIsDefined.php
+++ b/src/Diagnostics/ReverbDefaultServerIsDefined.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Laravel\Reverb\Diagnostics;
+
+use Laravel\Doctor\Diagnostic;
+use Laravel\Doctor\Results\DiagnosticResult;
+use Laravel\Doctor\Results\Link;
+use Laravel\Doctor\Results\Message;
+
+class ReverbDefaultServerIsDefined extends Diagnostic
+{
+    use ResolvesReverbConfiguration;
+
+    public string $name = 'Reverb server is defined';
+
+    public string $group = 'reverb';
+
+    /**
+     * Get the diagnostic's named message definitions.
+     *
+     * @return array<string, string|Message>
+     */
+    protected function messages(): array
+    {
+        return [
+            'not-used' => 'The active broadcast connection does not use Reverb.',
+            'not-defined' => Message::make(
+                summary: 'The default Reverb server [{server}] is not defined in `reverb.servers`.',
+                remediation: 'Define the [{server}] server in `reverb.servers` so the Reverb server has host, port, and scaling configuration.',
+            )->link(Link::docs('reverb', 'configuration')),
+            'defined' => 'The default Reverb server [{server}] is defined.',
+        ];
+    }
+
+    /**
+     * Run the diagnostic.
+     *
+     * A default naming an unsupported driver dies during service provider
+     * registration, before Doctor can run, so only a missing or empty server
+     * entry for the resolvable default is observable here.
+     */
+    public function check(): DiagnosticResult
+    {
+        if ($this->reverbConnection() === null) {
+            return $this->skip('not-used');
+        }
+
+        $server = $this->defaultServer();
+
+        if ($this->defaultServerConfiguration() === null) {
+            return $this->fail('not-defined', ['server' => $server]);
+        }
+
+        return $this->pass('defined', ['server' => $server]);
+    }
+}

--- a/src/Diagnostics/ReverbScalingRedisIsReachable.php
+++ b/src/Diagnostics/ReverbScalingRedisIsReachable.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Laravel\Reverb\Diagnostics;
+
+use Illuminate\Redis\RedisManager;
+use Laravel\Doctor\Diagnostic;
+use Laravel\Doctor\Results\DiagnosticResult;
+use Laravel\Doctor\Results\Link;
+use Laravel\Doctor\Results\Message;
+use Laravel\Doctor\Support\Configured;
+use Throwable;
+
+class ReverbScalingRedisIsReachable extends Diagnostic
+{
+    use ResolvesReverbConfiguration;
+
+    public string $name = 'Reverb scaling Redis connects';
+
+    public string $group = 'reverb';
+
+    /**
+     * Get the diagnostic's named message definitions.
+     *
+     * @return array<string, string|Message>
+     */
+    protected function messages(): array
+    {
+        return [
+            'not-used' => 'The active broadcast connection does not use Reverb.',
+            'no-server' => 'The default Reverb server is not defined.',
+            'disabled' => 'Reverb scaling is disabled.',
+            'unreachable' => Message::make(
+                summary: 'The Redis server used for Reverb scaling cannot be reached.',
+                remediation: 'Check the `REDIS_*` values used by Reverb\'s `scaling.server` configuration.',
+            )->link(Link::docs('reverb', 'scaling')),
+            'reachable' => 'The Redis server used for Reverb scaling is reachable.',
+        ];
+    }
+
+    /**
+     * Run the diagnostic.
+     */
+    public function check(): DiagnosticResult
+    {
+        if ($this->reverbConnection() === null) {
+            return $this->skip('not-used');
+        }
+
+        $configuration = $this->defaultServerConfiguration();
+
+        if ($configuration === null) {
+            return $this->skip('no-server');
+        }
+
+        if (! ($configuration['scaling']['enabled'] ?? false)) {
+            return $this->skip('disabled');
+        }
+
+        try {
+            $this->probe((array) ($configuration['scaling']['server'] ?? []));
+        } catch (Throwable $e) {
+            return $this->fail('unreachable')->withDetails($e->getMessage());
+        }
+
+        return $this->pass('reachable');
+    }
+
+    /**
+     * Probe the Redis server Reverb publishes scaling events through.
+     *
+     * Reverb falls back to the default framework Redis connection when the
+     * scaling server configuration is empty, so the probe does the same.
+     *
+     * @param  array<string, mixed>  $configuration
+     */
+    private function probe(array $configuration): void
+    {
+        if ($configuration === []) {
+            $configuration = (array) config('database.redis.default');
+        }
+
+        $manager = new RedisManager(
+            app(),
+            Configured::string('database.redis.client', 'phpredis'),
+            ['default' => [...$configuration, 'timeout' => 2.0]],
+        );
+
+        $manager->connection()->ping();
+    }
+}

--- a/src/ReverbServiceProvider.php
+++ b/src/ReverbServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Laravel\Reverb;
 
 use Illuminate\Support\ServiceProvider;
+use Laravel\Doctor\Doctor;
 use Laravel\Pulse\Pulse;
 use Laravel\Reverb\Console\Commands\InstallCommand;
 use Laravel\Reverb\Contracts\Logger;
@@ -35,6 +36,8 @@ class ReverbServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        $this->registerDiagnostics();
+
         if ($this->app->runningInConsole()) {
             $this->commands(InstallCommand::class);
 
@@ -57,5 +60,23 @@ class ReverbServiceProvider extends ServiceProvider
         }
 
         $this->app->make(ServerProviderManager::class)->boot();
+    }
+
+    /**
+     * Register the package's Doctor diagnostics.
+     */
+    protected function registerDiagnostics(): void
+    {
+        if ($this->app->bound(Doctor::class)) {
+            $this->app->make(Doctor::class)->diagnostics([
+                Diagnostics\ReverbConfigurationValuesAreSet::class,
+                Diagnostics\ReverbConnectionIsReachable::class,
+                Diagnostics\ReverbDefaultServerIsDefined::class,
+                Diagnostics\ReverbAppsAreConfigured::class,
+                Diagnostics\ReverbBroadcasterCredentialsMatchApp::class,
+                Diagnostics\ReverbAllowedOriginsCoverAppUrl::class,
+                Diagnostics\ReverbScalingRedisIsReachable::class,
+            ]);
+        }
     }
 }

--- a/tests/Feature/Diagnostics/DiagnosticsTestCase.php
+++ b/tests/Feature/Diagnostics/DiagnosticsTestCase.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Laravel\Reverb\Tests\Feature\Diagnostics;
+
+use Laravel\Doctor\DoctorServiceProvider;
+use Laravel\Reverb\Tests\TestCase;
+
+abstract class DiagnosticsTestCase extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (! class_exists(DoctorServiceProvider::class)) {
+            $this->markTestSkipped('laravel/doctor is not installed.');
+        }
+
+        parent::setUp();
+    }
+
+    protected function getPackageProviders($app)
+    {
+        return [
+            ...parent::getPackageProviders($app),
+            DoctorServiceProvider::class,
+        ];
+    }
+}

--- a/tests/Feature/Diagnostics/ReverbAllowedOriginsCoverAppUrlTest.php
+++ b/tests/Feature/Diagnostics/ReverbAllowedOriginsCoverAppUrlTest.php
@@ -1,0 +1,137 @@
+<?php
+
+use Laravel\Doctor\Facades\Doctor;
+use Laravel\Doctor\Results\Status;
+use Laravel\Reverb\Diagnostics\ReverbAllowedOriginsCoverAppUrl;
+use Laravel\Reverb\Tests\Feature\Diagnostics\DiagnosticsTestCase;
+
+uses(DiagnosticsTestCase::class);
+
+it('is registered with doctor', function () {
+    expect(Doctor::registered())->toContain(ReverbAllowedOriginsCoverAppUrl::class);
+});
+
+it('skips when reverb is not active', function () {
+    config(['broadcasting.default' => 'null']);
+
+    $result = (new ReverbAllowedOriginsCoverAppUrl)->check();
+
+    expect($result->status)->toBe(Status::Skip);
+    expect($result->summary)->toBe('The active broadcast connection does not use Reverb.');
+});
+
+it('skips when no application matches the broadcast connection', function () {
+    configureReverbOrigins(broadcasterKey: 'unknown-key');
+
+    $result = (new ReverbAllowedOriginsCoverAppUrl)->check();
+
+    expect($result->status)->toBe(Status::Skip);
+    expect($result->summary)->toBe('No Reverb application matches the broadcast connection, so allowed origins were not checked.');
+});
+
+it('skips when the application url is not configured', function () {
+    configureReverbOrigins(origins: ['example.com']);
+
+    config(['app.url' => null]);
+
+    $result = (new ReverbAllowedOriginsCoverAppUrl)->check();
+
+    expect($result->status)->toBe(Status::Skip);
+    expect($result->summary)->toBe('The application URL is not configured, so allowed origins were not checked.');
+});
+
+it('fails when no origins are allowed', function () {
+    configureReverbOrigins(origins: []);
+
+    $result = (new ReverbAllowedOriginsCoverAppUrl)->check();
+
+    expect($result->status)->toBe(Status::Fail);
+    expect($result->summary)->toBe('The Reverb application does not allow any origins.');
+});
+
+it('passes when every origin is allowed', function () {
+    configureReverbOrigins(origins: ['*']);
+
+    $result = (new ReverbAllowedOriginsCoverAppUrl)->check();
+
+    expect($result->status)->toBe(Status::Pass);
+    expect($result->summary)->toBe('The Reverb application allows connections from any origin.');
+});
+
+it('fails when the app host is not allowed', function () {
+    configureReverbOrigins(origins: ['example.com']);
+
+    config(['app.url' => 'https://myapp.test']);
+
+    $result = (new ReverbAllowedOriginsCoverAppUrl)->check();
+
+    expect($result->status)->toBe(Status::Fail);
+    expect($result->summary)->toBe('The Reverb application\'s allowed origins do not include the application\'s own host.');
+    expect($result->details)->toBe('- myapp.test');
+});
+
+it('fails when the frontend host is not allowed', function () {
+    configureReverbOrigins(origins: ['myapp.test']);
+
+    config(['app.url' => 'https://myapp.test', 'app.frontend_url' => 'https://front.test']);
+
+    $result = (new ReverbAllowedOriginsCoverAppUrl)->check();
+
+    expect($result->status)->toBe(Status::Fail);
+    expect($result->details)->toBe('- front.test');
+});
+
+it('ignores the app url when a frontend url is configured', function () {
+    configureReverbOrigins(origins: ['front.test']);
+
+    config(['app.url' => 'https://api.test', 'app.frontend_url' => 'https://front.test']);
+
+    $result = (new ReverbAllowedOriginsCoverAppUrl)->check();
+
+    expect($result->status)->toBe(Status::Pass);
+});
+
+it('passes when the app host is allowed', function () {
+    configureReverbOrigins(origins: ['myapp.test']);
+
+    config(['app.url' => 'https://myapp.test']);
+
+    $result = (new ReverbAllowedOriginsCoverAppUrl)->check();
+
+    expect($result->status)->toBe(Status::Pass);
+    expect($result->summary)->toBe('The Reverb application allows connections from the application\'s host.');
+});
+
+it('passes when a wildcard origin matches', function () {
+    configureReverbOrigins(origins: ['*.myapp.test']);
+
+    config(['app.url' => 'https://ws.myapp.test']);
+
+    $result = (new ReverbAllowedOriginsCoverAppUrl)->check();
+
+    expect($result->status)->toBe(Status::Pass);
+});
+
+/**
+ * Configure the Reverb broadcast connection and an application with the given origins.
+ *
+ * @param  list<string>  $origins
+ */
+function configureReverbOrigins(array $origins = ['*'], string $broadcasterKey = 'reverb-key'): void
+{
+    config([
+        'app.frontend_url' => null,
+        'broadcasting.default' => 'reverb',
+        'broadcasting.connections.reverb' => [
+            'driver' => 'reverb',
+            'key' => $broadcasterKey,
+        ],
+        'reverb.apps.provider' => 'config',
+        'reverb.apps.apps' => [[
+            'key' => 'reverb-key',
+            'secret' => 'reverb-secret',
+            'app_id' => '123456',
+            'allowed_origins' => $origins,
+        ]],
+    ]);
+}

--- a/tests/Feature/Diagnostics/ReverbAppsAreConfiguredTest.php
+++ b/tests/Feature/Diagnostics/ReverbAppsAreConfiguredTest.php
@@ -1,0 +1,174 @@
+<?php
+
+use Laravel\Doctor\Facades\Doctor;
+use Laravel\Doctor\Results\Status;
+use Laravel\Reverb\Diagnostics\ReverbAppsAreConfigured;
+use Laravel\Reverb\Tests\Feature\Diagnostics\DiagnosticsTestCase;
+
+uses(DiagnosticsTestCase::class);
+
+it('is registered with doctor', function () {
+    expect(Doctor::registered())->toContain(ReverbAppsAreConfigured::class);
+});
+
+it('skips when reverb is not active', function () {
+    config(['broadcasting.default' => 'null']);
+
+    $result = (new ReverbAppsAreConfigured)->check();
+
+    expect($result->status)->toBe(Status::Skip);
+    expect($result->summary)->toBe('The active broadcast connection does not use Reverb.');
+});
+
+it('skips when apps are not managed by the config provider', function () {
+    activateReverbApps();
+
+    config(['reverb.apps.provider' => 'custom']);
+
+    $result = (new ReverbAppsAreConfigured)->check();
+
+    expect($result->status)->toBe(Status::Skip);
+    expect($result->summary)->toBe('Reverb applications are not managed by the config provider.');
+});
+
+it('fails when no apps are defined', function () {
+    activateReverbApps();
+
+    config(['reverb.apps.apps' => []]);
+
+    $result = (new ReverbAppsAreConfigured)->check();
+
+    expect($result->status)->toBe(Status::Fail);
+    expect($result->summary)->toBe('No Reverb applications are defined.');
+});
+
+it('fails with the missing credential paths', function () {
+    activateReverbApps();
+
+    config(['reverb.apps.apps' => [
+        reverbApp(['secret' => null, 'app_id' => '']),
+    ]]);
+
+    $result = (new ReverbAppsAreConfigured)->check();
+
+    expect($result->status)->toBe(Status::Fail);
+    expect($result->summary)->toBe('Some Reverb applications are missing credentials.');
+    expect($result->details)->toBe(
+        "- reverb.apps.apps.0.app_id\n- reverb.apps.apps.0.secret"
+    );
+});
+
+it('skips when the broadcast connection is missing the same credentials', function () {
+    activateReverbApps();
+
+    config([
+        'broadcasting.connections.reverb' => ['driver' => 'reverb'],
+        'reverb.apps.apps' => [
+            reverbApp(['key' => null, 'secret' => null, 'app_id' => null]),
+        ],
+    ]);
+
+    $result = (new ReverbAppsAreConfigured)->check();
+
+    expect($result->status)->toBe(Status::Skip);
+    expect($result->summary)->toBe('The Reverb broadcast connection is missing required configuration.');
+});
+
+it('still reports credentials the broadcast connection has', function () {
+    activateReverbApps();
+
+    config([
+        'broadcasting.connections.reverb.app_id' => null,
+        'reverb.apps.apps' => [
+            reverbApp(['app_id' => null]),
+            reverbApp(['key' => 'second-key', 'app_id' => '222222', 'secret' => null]),
+        ],
+    ]);
+
+    $result = (new ReverbAppsAreConfigured)->check();
+
+    expect($result->status)->toBe(Status::Fail);
+    expect($result->details)->toBe('- reverb.apps.apps.1.secret');
+});
+
+it('fails when an app omits options the server requires', function () {
+    activateReverbApps();
+
+    $app = reverbApp();
+    unset($app['ping_interval'], $app['max_message_size']);
+
+    config(['reverb.apps.apps' => [$app]]);
+
+    $result = (new ReverbAppsAreConfigured)->check();
+
+    expect($result->status)->toBe(Status::Fail);
+    expect($result->summary)->toBe('Some Reverb applications are missing options the server requires.');
+    expect($result->details)->toBe(
+        "- reverb.apps.apps.0.ping_interval\n- reverb.apps.apps.0.max_message_size"
+    );
+});
+
+it('fails when applications share credentials', function () {
+    activateReverbApps();
+
+    config(['reverb.apps.apps' => [
+        reverbApp(['secret' => 'first-secret', 'app_id' => '111111']),
+        reverbApp(['secret' => 'second-secret', 'app_id' => '222222']),
+    ]]);
+
+    $result = (new ReverbAppsAreConfigured)->check();
+
+    expect($result->status)->toBe(Status::Fail);
+    expect($result->summary)->toBe('Multiple Reverb applications share the same key or app ID.');
+    expect($result->details)->toBe('- key [reverb-key] is used by 2 applications');
+});
+
+it('passes when every app is configured', function () {
+    activateReverbApps();
+
+    config(['reverb.apps.apps' => [
+        reverbApp(['key' => 'first-key', 'app_id' => '111111']),
+        reverbApp(['key' => 'second-key', 'app_id' => 222222]),
+    ]]);
+
+    $result = (new ReverbAppsAreConfigured)->check();
+
+    expect($result->status)->toBe(Status::Pass);
+    expect($result->summary)->toBe('Every Reverb application has the credentials and options the server requires.');
+});
+
+/**
+ * Activate Reverb with config-provided applications.
+ */
+function activateReverbApps(): void
+{
+    config([
+        'broadcasting.default' => 'reverb',
+        'broadcasting.connections.reverb' => [
+            'driver' => 'reverb',
+            'key' => 'reverb-key',
+            'secret' => 'reverb-secret',
+            'app_id' => '123456',
+        ],
+        'reverb.apps.provider' => 'config',
+    ]);
+}
+
+/**
+ * Build a fully configured application.
+ *
+ * @param  array<string, mixed>  $overrides
+ * @return array<string, mixed>
+ */
+function reverbApp(array $overrides = []): array
+{
+    return [
+        'key' => 'reverb-key',
+        'secret' => 'reverb-secret',
+        'app_id' => '123456',
+        'ping_interval' => 60,
+        'allowed_origins' => ['*'],
+        'max_message_size' => 10_000,
+        ...$overrides,
+    ];
+}

--- a/tests/Feature/Diagnostics/ReverbBroadcasterCredentialsMatchAppTest.php
+++ b/tests/Feature/Diagnostics/ReverbBroadcasterCredentialsMatchAppTest.php
@@ -1,0 +1,107 @@
+<?php
+
+use Laravel\Doctor\Facades\Doctor;
+use Laravel\Doctor\Results\Status;
+use Laravel\Reverb\Diagnostics\ReverbBroadcasterCredentialsMatchApp;
+use Laravel\Reverb\Tests\Feature\Diagnostics\DiagnosticsTestCase;
+
+uses(DiagnosticsTestCase::class);
+
+it('is registered with doctor', function () {
+    expect(Doctor::registered())->toContain(ReverbBroadcasterCredentialsMatchApp::class);
+});
+
+it('skips when reverb is not active', function () {
+    config(['broadcasting.default' => 'null']);
+
+    $result = (new ReverbBroadcasterCredentialsMatchApp)->check();
+
+    expect($result->status)->toBe(Status::Skip);
+    expect($result->summary)->toBe('The active broadcast connection does not use Reverb.');
+});
+
+it('skips when apps are not managed by the config provider', function () {
+    configureReverbCredentials();
+
+    config(['reverb.apps.provider' => 'custom']);
+
+    $result = (new ReverbBroadcasterCredentialsMatchApp)->check();
+
+    expect($result->status)->toBe(Status::Skip);
+    expect($result->summary)->toBe('Reverb applications are not managed by the config provider.');
+});
+
+it('skips when the broadcast connection is not configured', function () {
+    configureReverbCredentials(broadcaster: ['key' => null]);
+
+    $result = (new ReverbBroadcasterCredentialsMatchApp)->check();
+
+    expect($result->status)->toBe(Status::Skip);
+    expect($result->summary)->toBe('The Reverb broadcast connection is missing required configuration.');
+});
+
+it('fails when no application matches the key', function () {
+    configureReverbCredentials(broadcaster: ['key' => 'unknown-key']);
+
+    $result = (new ReverbBroadcasterCredentialsMatchApp)->check();
+
+    expect($result->status)->toBe(Status::Fail);
+    expect($result->summary)->toBe('No Reverb application matches the broadcast connection\'s key.');
+    expect($result->remediation)->toContain('REVERB_APP_KEY');
+});
+
+it('fails when the matched application has different credentials', function () {
+    configureReverbCredentials(app: ['secret' => 'other-secret', 'app_id' => '999999']);
+
+    $result = (new ReverbBroadcasterCredentialsMatchApp)->check();
+
+    expect($result->status)->toBe(Status::Fail);
+    expect($result->summary)->toBe('The Reverb application matching the broadcast connection\'s key has different credentials.');
+    expect($result->details)->toBe(
+        "- The application's app_id does not match the broadcast connection.\n- The application's secret does not match the broadcast connection."
+    );
+});
+
+it('passes when the credentials match', function () {
+    configureReverbCredentials();
+
+    $result = (new ReverbBroadcasterCredentialsMatchApp)->check();
+
+    expect($result->status)->toBe(Status::Pass);
+    expect($result->summary)->toBe('The broadcast connection credentials match a Reverb application.');
+});
+
+it('passes when a numeric app id matches', function () {
+    configureReverbCredentials(app: ['app_id' => 123456]);
+
+    $result = (new ReverbBroadcasterCredentialsMatchApp)->check();
+
+    expect($result->status)->toBe(Status::Pass);
+});
+
+/**
+ * Configure the Reverb broadcast connection and a matching application.
+ *
+ * @param  array<string, mixed>  $broadcaster
+ * @param  array<string, mixed>  $app
+ */
+function configureReverbCredentials(array $broadcaster = [], array $app = []): void
+{
+    config([
+        'broadcasting.default' => 'reverb',
+        'broadcasting.connections.reverb' => [
+            'driver' => 'reverb',
+            'key' => 'reverb-key',
+            'secret' => 'reverb-secret',
+            'app_id' => '123456',
+            ...$broadcaster,
+        ],
+        'reverb.apps.provider' => 'config',
+        'reverb.apps.apps' => [[
+            'key' => 'reverb-key',
+            'secret' => 'reverb-secret',
+            'app_id' => '123456',
+            ...$app,
+        ]],
+    ]);
+}

--- a/tests/Feature/Diagnostics/ReverbConfigurationValuesAreSetTest.php
+++ b/tests/Feature/Diagnostics/ReverbConfigurationValuesAreSetTest.php
@@ -1,0 +1,68 @@
+<?php
+
+use Laravel\Doctor\Facades\Doctor;
+use Laravel\Doctor\Results\Status;
+use Laravel\Reverb\Diagnostics\ReverbConfigurationValuesAreSet;
+use Laravel\Reverb\Tests\Feature\Diagnostics\DiagnosticsTestCase;
+
+uses(DiagnosticsTestCase::class);
+
+it('is registered with doctor', function () {
+    expect(Doctor::registered())->toContain(ReverbConfigurationValuesAreSet::class);
+});
+
+it('skips when reverb is not active', function () {
+    config(['broadcasting.default' => 'null']);
+
+    $result = (new ReverbConfigurationValuesAreSet)->check();
+
+    expect($result->status)->toBe(Status::Skip);
+    expect($result->summary)->toBe('The active broadcast connection does not use Reverb.');
+});
+
+it('passes when required values are set', function () {
+    configureReverbConnectionValues([
+        'app_id' => '123456',
+        'key' => 'reverb-key',
+        'secret' => 'reverb-secret',
+        'options' => ['host' => 'reverb.test'],
+    ]);
+
+    $result = (new ReverbConfigurationValuesAreSet)->check();
+
+    expect($result->status)->toBe(Status::Pass);
+    expect($result->summary)->toBe('Every configuration value required by the active Reverb broadcast connection is set.');
+});
+
+it('fails with the missing configuration keys', function () {
+    configureReverbConnectionValues([
+        'app_id' => null,
+        'key' => 'reverb-key',
+        'secret' => '',
+        'options' => ['host' => null],
+    ]);
+
+    $result = (new ReverbConfigurationValuesAreSet)->check();
+
+    expect($result->status)->toBe(Status::Fail);
+    expect($result->summary)->toBe('Some configuration values required by the active Reverb broadcast connection are not set.');
+    expect($result->details)->toBe(
+        "- broadcasting.connections.reverb.app_id\n- broadcasting.connections.reverb.secret\n- broadcasting.connections.reverb.options.host"
+    );
+});
+
+/**
+ * Configure the Reverb broadcast connection.
+ *
+ * @param  array<string, mixed>  $configuration
+ */
+function configureReverbConnectionValues(array $configuration): void
+{
+    config([
+        'broadcasting.default' => 'reverb',
+        'broadcasting.connections.reverb' => [
+            'driver' => 'reverb',
+            ...$configuration,
+        ],
+    ]);
+}

--- a/tests/Feature/Diagnostics/ReverbConnectionIsReachableTest.php
+++ b/tests/Feature/Diagnostics/ReverbConnectionIsReachableTest.php
@@ -1,0 +1,116 @@
+<?php
+
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response;
+use Laravel\Doctor\Facades\Doctor;
+use Laravel\Doctor\Results\Status;
+use Laravel\Reverb\Diagnostics\ReverbConnectionIsReachable;
+use Laravel\Reverb\Tests\Feature\Diagnostics\DiagnosticsTestCase;
+
+uses(DiagnosticsTestCase::class);
+
+it('is registered with doctor', function () {
+    expect(Doctor::registered())->toContain(ReverbConnectionIsReachable::class);
+});
+
+it('skips without probing when reverb is not active', function () {
+    config(['broadcasting.default' => 'null']);
+
+    $result = (new ReverbConnectionIsReachable)->check();
+
+    expect($result->status)->toBe(Status::Skip);
+    expect($result->summary)->toBe('The active broadcast connection does not use Reverb.');
+});
+
+it('skips without probing when required configuration is missing', function () {
+    config([
+        'broadcasting.default' => 'reverb',
+        'broadcasting.connections.reverb' => [
+            'driver' => 'reverb',
+            'app_id' => null,
+            'key' => 'key',
+            'secret' => '',
+            'options' => ['host' => null],
+        ],
+    ]);
+
+    $result = (new ReverbConnectionIsReachable)->check();
+
+    expect($result->status)->toBe(Status::Skip);
+    expect($result->summary)->toBe('The Reverb broadcast connection is missing required configuration.');
+});
+
+it('uses a signed read-only request to probe reverb', function () {
+    $history = [];
+    $stack = HandlerStack::create(new MockHandler([
+        new Response(200, [], '{"channels":{}}'),
+    ]));
+    $stack->push(Middleware::history($history));
+
+    configureReachableReverb($stack);
+
+    $result = (new ReverbConnectionIsReachable)->check();
+
+    expect($result->status)->toBe(Status::Pass);
+    expect($result->summary)->toBe('The application can connect to Reverb using broadcast connection [reverb].');
+    expect($history)->toHaveCount(1);
+    expect($history[0]['request']->getMethod())->toBe('GET');
+    expect($history[0]['request']->getUri()->getPath())->toBe('/apps/123456/channels');
+    expect($history[0]['request']->getUri()->getQuery())->toContain('auth_key=reverb-key');
+    expect($history[0]['request']->getUri()->getQuery())->toContain('auth_signature=');
+    expect($history[0]['options']['connect_timeout'])->toBe(2);
+    expect($history[0]['options']['timeout'])->toBe(2);
+});
+
+it('fails when the endpoint does not return a reverb response', function () {
+    $stack = HandlerStack::create(new MockHandler([
+        new Response(200, [], '{"status":"ok"}'),
+    ]));
+
+    configureReachableReverb($stack);
+
+    $result = (new ReverbConnectionIsReachable)->check();
+
+    expect($result->status)->toBe(Status::Fail);
+    expect($result->details)->toBe('The Reverb channels endpoint returned an unexpected response.');
+});
+
+it('fails when reverb rejects the connection', function () {
+    $stack = HandlerStack::create(new MockHandler([
+        new Response(401, [], 'Invalid credentials.'),
+    ]));
+
+    configureReachableReverb($stack);
+
+    $result = (new ReverbConnectionIsReachable)->check();
+
+    expect($result->status)->toBe(Status::Fail);
+    expect($result->summary)->toBe('The application cannot connect to Reverb using broadcast connection [reverb].');
+    expect($result->details)->toContain('Invalid credentials.');
+});
+
+/**
+ * Configure a Reverb broadcast connection backed by the given Guzzle handler.
+ */
+function configureReachableReverb(callable $handler): void
+{
+    config([
+        'broadcasting.default' => 'reverb',
+        'broadcasting.connections.reverb' => [
+            'driver' => 'reverb',
+            'app_id' => '123456',
+            'key' => 'reverb-key',
+            'secret' => 'reverb-secret',
+            'options' => [
+                'host' => 'reverb.test',
+                'port' => 443,
+                'scheme' => 'https',
+                'useTLS' => true,
+                'path' => '/reverb',
+            ],
+            'client_options' => ['handler' => $handler],
+        ],
+    ]);
+}

--- a/tests/Feature/Diagnostics/ReverbDefaultServerIsDefinedTest.php
+++ b/tests/Feature/Diagnostics/ReverbDefaultServerIsDefinedTest.php
@@ -1,0 +1,64 @@
+<?php
+
+use Laravel\Doctor\Facades\Doctor;
+use Laravel\Doctor\Results\Status;
+use Laravel\Reverb\Diagnostics\ReverbDefaultServerIsDefined;
+use Laravel\Reverb\Tests\Feature\Diagnostics\DiagnosticsTestCase;
+
+uses(DiagnosticsTestCase::class);
+
+it('is registered with doctor', function () {
+    expect(Doctor::registered())->toContain(ReverbDefaultServerIsDefined::class);
+});
+
+it('skips when reverb is not active', function () {
+    config(['broadcasting.default' => 'null']);
+
+    $result = (new ReverbDefaultServerIsDefined)->check();
+
+    expect($result->status)->toBe(Status::Skip);
+    expect($result->summary)->toBe('The active broadcast connection does not use Reverb.');
+});
+
+it('fails when the default server entry is missing', function () {
+    activateReverbForServer();
+
+    config(['reverb.servers' => []]);
+
+    $result = (new ReverbDefaultServerIsDefined)->check();
+
+    expect($result->status)->toBe(Status::Fail);
+    expect($result->summary)->toBe('The default Reverb server [reverb] is not defined in `reverb.servers`.');
+    expect($result->remediation)->toContain('reverb.servers');
+});
+
+it('fails when the default server entry is empty', function () {
+    activateReverbForServer();
+
+    config(['reverb.servers.reverb' => []]);
+
+    $result = (new ReverbDefaultServerIsDefined)->check();
+
+    expect($result->status)->toBe(Status::Fail);
+    expect($result->summary)->toBe('The default Reverb server [reverb] is not defined in `reverb.servers`.');
+});
+
+it('passes when the default server is defined', function () {
+    activateReverbForServer();
+
+    $result = (new ReverbDefaultServerIsDefined)->check();
+
+    expect($result->status)->toBe(Status::Pass);
+    expect($result->summary)->toBe('The default Reverb server [reverb] is defined.');
+});
+
+/**
+ * Activate Reverb as the default broadcast connection.
+ */
+function activateReverbForServer(): void
+{
+    config([
+        'broadcasting.default' => 'reverb',
+        'broadcasting.connections.reverb' => ['driver' => 'reverb'],
+    ]);
+}

--- a/tests/Feature/Diagnostics/ReverbScalingRedisIsReachableTest.php
+++ b/tests/Feature/Diagnostics/ReverbScalingRedisIsReachableTest.php
@@ -1,0 +1,83 @@
+<?php
+
+use Laravel\Doctor\Facades\Doctor;
+use Laravel\Doctor\Results\Status;
+use Laravel\Reverb\Diagnostics\ReverbScalingRedisIsReachable;
+use Laravel\Reverb\Tests\Feature\Diagnostics\DiagnosticsTestCase;
+
+uses(DiagnosticsTestCase::class);
+
+it('is registered with doctor', function () {
+    expect(Doctor::registered())->toContain(ReverbScalingRedisIsReachable::class);
+});
+
+it('skips when reverb is not active', function () {
+    config(['broadcasting.default' => 'null']);
+
+    $result = (new ReverbScalingRedisIsReachable)->check();
+
+    expect($result->status)->toBe(Status::Skip);
+    expect($result->summary)->toBe('The active broadcast connection does not use Reverb.');
+});
+
+it('skips when the default server is not defined', function () {
+    activateReverbForScaling();
+
+    config(['reverb.servers' => []]);
+
+    $result = (new ReverbScalingRedisIsReachable)->check();
+
+    expect($result->status)->toBe(Status::Skip);
+    expect($result->summary)->toBe('The default Reverb server is not defined.');
+});
+
+it('skips when scaling is disabled', function () {
+    activateReverbForScaling();
+
+    config(['reverb.servers.reverb.scaling.enabled' => false]);
+
+    $result = (new ReverbScalingRedisIsReachable)->check();
+
+    expect($result->status)->toBe(Status::Skip);
+    expect($result->summary)->toBe('Reverb scaling is disabled.');
+});
+
+it('fails when the scaling redis server is unreachable', function () {
+    activateReverbForScaling();
+
+    config([
+        'reverb.servers.reverb.scaling.enabled' => true,
+        'reverb.servers.reverb.scaling.server' => ['host' => '127.0.0.1', 'port' => 1],
+    ]);
+
+    $result = (new ReverbScalingRedisIsReachable)->check();
+
+    expect($result->status)->toBe(Status::Fail);
+    expect($result->summary)->toBe('The Redis server used for Reverb scaling cannot be reached.');
+    expect($result->details)->not->toBe('');
+});
+
+it('falls back to the default redis connection', function () {
+    activateReverbForScaling();
+
+    config([
+        'reverb.servers.reverb.scaling.enabled' => true,
+        'reverb.servers.reverb.scaling.server' => [],
+        'database.redis.default' => ['host' => '127.0.0.1', 'port' => 1],
+    ]);
+
+    $result = (new ReverbScalingRedisIsReachable)->check();
+
+    expect($result->status)->toBe(Status::Fail);
+});
+
+/**
+ * Activate Reverb as the default broadcast connection.
+ */
+function activateReverbForScaling(): void
+{
+    config([
+        'broadcasting.default' => 'reverb',
+        'broadcasting.connections.reverb' => ['driver' => 'reverb'],
+    ]);
+}


### PR DESCRIPTION
This PR registers seven Reverb diagnostics with `laravel/doctor` when it is installed.

- `ReverbConfigurationValuesAreSet` fails when the active Reverb broadcast connection lacks an app ID, key, secret, or public host.
- `ReverbConnectionIsReachable` probes the server through the broadcast connection with a signed, read-only request to the channels endpoint using short timeouts.
- `ReverbDefaultServerIsDefined` fails when the server named by `reverb.default` has no entry in `reverb.servers`.
- `ReverbAppsAreConfigured` fails when no applications are defined, credentials are missing, options the server reads without fallbacks (`ping_interval`, `allowed_origins`, `max_message_size`) are omitted, or multiple applications share a key or app ID.
- `ReverbBroadcasterCredentialsMatchApp` fails when no application matches the broadcast connection's key, or the matched application's app ID or secret differ from the connection.
- `ReverbAllowedOriginsCoverAppUrl` fails when the matched application allows no origins or its allowed origins don't cover the application's host.
- `ReverbScalingRedisIsReachable` pings the Redis server used for scaling when scaling is enabled.