### PR TITLE
Prefer an identified connection when flattening channel connections

### DIFF
--- a/src/Protocols/Pusher/Http/Controllers/UsersTerminateController.php
+++ b/src/Protocols/Pusher/Http/Controllers/UsersTerminateController.php
@@ -29,7 +29,7 @@ class UsersTerminateController extends Controller
         $connections = collect($this->channels->connections());
 
         $connections->each(function ($connection) use ($userId) {
-            if ((string) $connection->data()['user_id'] === $userId) {
+            if ((string) $connection->data('user_id') === $userId) {
                 $connection->disconnect();
             }
         });

--- a/src/Protocols/Pusher/Managers/ArrayChannelManager.php
+++ b/src/Protocols/Pusher/Managers/ArrayChannelManager.php
@@ -97,14 +97,7 @@ class ArrayChannelManager implements ChannelManagerInterface
 
         foreach ($channels as $ch) {
             foreach ($ch->connections() as $identifier => $connection) {
-                // A connection is stored per channel, so a socket subscribed to
-                // several channels appears once for each of them. Only presence
-                // channels (and private channels given signed channel data)
-                // carry the subscriber's identity, so prefer a wrapper that has
-                // one: without this the first channel iterated wins, and if that
-                // is an anonymous public channel the socket cannot be matched by
-                // user ID even though another of its wrappers knows exactly who
-                // it belongs to.
+                // Prefer connections with user data when a socket has multiple channel subscriptions...
                 if (! isset($result[$identifier]) || ($result[$identifier]->data('user_id') === null && $connection->data('user_id') !== null)) {
                     $result[$identifier] = $connection;
                 }

--- a/src/Protocols/Pusher/Managers/ArrayChannelManager.php
+++ b/src/Protocols/Pusher/Managers/ArrayChannelManager.php
@@ -96,7 +96,19 @@ class ArrayChannelManager implements ChannelManagerInterface
         $result = [];
 
         foreach ($channels as $ch) {
-            $result += $ch->connections();
+            foreach ($ch->connections() as $identifier => $connection) {
+                // A connection is stored per channel, so a socket subscribed to
+                // several channels appears once for each of them. Only presence
+                // channels (and private channels given signed channel data)
+                // carry the subscriber's identity, so prefer a wrapper that has
+                // one: without this the first channel iterated wins, and if that
+                // is an anonymous public channel the socket cannot be matched by
+                // user ID even though another of its wrappers knows exactly who
+                // it belongs to.
+                if (! isset($result[$identifier]) || ($result[$identifier]->data('user_id') === null && $connection->data('user_id') !== null)) {
+                    $result[$identifier] = $connection;
+                }
+            }
         }
 
         return $result;

--- a/src/Protocols/Pusher/PusherPubSubIncomingMessageHandler.php
+++ b/src/Protocols/Pusher/PusherPubSubIncomingMessageHandler.php
@@ -38,7 +38,7 @@ class PusherPubSubIncomingMessageHandler implements PubSubIncomingMessageHandler
             ),
             'terminate' => collect(app(ChannelManager::class)->for($application)->connections())
                 ->each(function ($connection) use ($event) {
-                    if ((string) $connection->data()['user_id'] === $event['payload']['user_id']) {
+                    if ((string) $connection->data('user_id') === $event['payload']['user_id']) {
                         $connection->disconnect();
                     }
                 }),

--- a/tests/Unit/Protocols/Pusher/Managers/ChannelManagerTest.php
+++ b/tests/Unit/Protocols/Pusher/Managers/ChannelManagerTest.php
@@ -128,3 +128,31 @@ it('can get all connections for all channels', function () {
     expect($channelTwo->connections())->toHaveCount(8);
     expect($channelThree->connections())->toHaveCount(12);
 });
+
+it('prefers a connection which knows its subscriber over an anonymous one', function () {
+    $anonymous = $this->channelManager->findOrCreate('anonymous-channel');
+    $identified = $this->channelManager->findOrCreate('identified-channel');
+
+    // The anonymous channel is created and subscribed to first, so it is the
+    // one a merge keyed on the connection identifier would otherwise keep.
+    $anonymous->subscribe($this->connection);
+    $identified->subscribe($this->connection, data: json_encode(['user_id' => '1']));
+
+    $connections = $this->channelManager->connections();
+
+    expect($connections)->toHaveCount(1)
+        ->and($connections[$this->connection->id()]->data('user_id'))->toBe('1');
+});
+
+it('keeps the subscriber when the identified channel is subscribed to first', function () {
+    $identified = $this->channelManager->findOrCreate('identified-channel');
+    $anonymous = $this->channelManager->findOrCreate('anonymous-channel');
+
+    $identified->subscribe($this->connection, data: json_encode(['user_id' => '1']));
+    $anonymous->subscribe($this->connection);
+
+    $connections = $this->channelManager->connections();
+
+    expect($connections)->toHaveCount(1)
+        ->and($connections[$this->connection->id()]->data('user_id'))->toBe('1');
+});


### PR DESCRIPTION
`ChannelManager::connections()` flattens the per-channel connection maps with `+=`:

```php
foreach ($channels as $ch) {
    $result += $ch->connections();
}
```

A connection is stored per channel, so a socket subscribed to several channels appears once for each of them, keyed by the same identifier. `+=` keeps the left-hand value, so the winner is whichever channel the manager happens to iterate first.

That matters because identity is stored per channel too: only presence subscriptions carry `user_id` (`InteractsWithPresenceChannels::subscribe()` → `Channel::subscribe()`). A public or private subscription stores empty data.

So when a socket holds both a public and a presence channel, and the public one was created first, `connections()` returns the anonymous wrapper. `UsersTerminateController` then reads `$connection->data()['user_id']`, finds nothing, and the socket is never disconnected — even though another of its wrappers knows exactly who it belongs to.

The practical effect is that `POST /apps/{appId}/users/{userId}/terminate_connections` returns success while the connection stays open and subscribed. Since the endpoint exists to end a user's sessions when their access is revoked, that failure is silent and order-dependent.

## Reproducing it

Any socket that subscribes to a public channel before a presence channel:

```js
// Registers an anonymous public channel first...
pusher.subscribe('anything')
// ...then a presence channel carrying the user's identity.
pusher.subscribe('presence-example')
```

Calling `terminate_connections` for that user leaves the socket connected. Reversing the two subscribe calls disconnects it.

I confirmed both directions against a running Reverb server by comparing `pusher.connection.socket_id` before and after the call: unchanged in the first ordering, replaced in the second.

## The change

Prefer a wrapper that carries a `user_id` over an anonymous one, so the result no longer depends on channel registration order. Where there is no conflict the behaviour is unchanged — it only breaks ties differently.

Two tests cover it: the failing ordering, and the reverse as a control. The first fails on `main`.
