### PR TITLE
Fix TypeError from WebSocket-only controller on non-upgrade requests (#344)

### DIFF
--- a/src/Servers/Reverb/Http/Router.php
+++ b/src/Servers/Reverb/Http/Router.php
@@ -66,6 +66,12 @@ class Router
             return $controller($request, $wsConnection, ...Arr::except($route, ['_controller', '_route']));
         }
 
+        if ($this->requiresWebSocketUpgrade($controller)) {
+            $this->close($connection, 426, 'Upgrade required.', ['Upgrade' => 'websocket']);
+
+            return null;
+        }
+
         $routeParameters = Arr::except($route, [
             '_controller',
             '_route',
@@ -95,7 +101,21 @@ class Router
      */
     protected function isWebSocketRequest(RequestInterface $request): bool
     {
-        return $request->getHeader('Upgrade')[0] ?? null === 'websocket';
+        return ($request->getHeader('Upgrade')[0] ?? null) === 'websocket';
+    }
+
+    /**
+     * Determine whether the controller requires an upgraded WebSocket connection.
+     */
+    protected function requiresWebSocketUpgrade(callable $controller): bool
+    {
+        foreach ($this->parameters($controller) as $parameter) {
+            if ($parameter['type'] === ReverbConnection::class) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/tests/FakeRawSocketConnection.php
+++ b/tests/FakeRawSocketConnection.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Laravel\Reverb\Tests;
+
+use React\Socket\ConnectionInterface;
+use React\Stream\WritableStreamInterface;
+
+/**
+ * A minimal fake of a raw ReactPHP socket connection, used to build a real
+ * `Laravel\Reverb\Servers\Reverb\Http\Connection` in tests without a socket.
+ */
+class FakeRawSocketConnection implements ConnectionInterface
+{
+    public $stream = 1;
+
+    /**
+     * Data written to the connection.
+     *
+     * @var array<int, string>
+     */
+    public array $written = [];
+
+    public bool $ended = false;
+
+    public function write($data)
+    {
+        $this->written[] = $data;
+
+        return true;
+    }
+
+    public function end($data = null)
+    {
+        $this->ended = true;
+    }
+
+    public function close()
+    {
+        //
+    }
+
+    public function pause()
+    {
+        //
+    }
+
+    public function resume()
+    {
+        //
+    }
+
+    public function pipe(WritableStreamInterface $dest, array $options = [])
+    {
+        return $dest;
+    }
+
+    public function isReadable()
+    {
+        return true;
+    }
+
+    public function isWritable()
+    {
+        return true;
+    }
+
+    public function getRemoteAddress()
+    {
+        return null;
+    }
+
+    public function getLocalAddress()
+    {
+        return null;
+    }
+
+    public function on($event, callable $listener)
+    {
+        //
+    }
+
+    public function once($event, callable $listener)
+    {
+        //
+    }
+
+    public function removeListener($event, callable $listener)
+    {
+        //
+    }
+
+    public function removeAllListeners($event = null)
+    {
+        //
+    }
+
+    public function listeners($event = null)
+    {
+        return [];
+    }
+
+    public function emit($event, array $arguments = [])
+    {
+        //
+    }
+}

--- a/tests/Unit/Servers/Reverb/Http/RouterTest.php
+++ b/tests/Unit/Servers/Reverb/Http/RouterTest.php
@@ -1,0 +1,110 @@
+<?php
+
+use GuzzleHttp\Psr7\Request;
+use Laravel\Reverb\Servers\Reverb\Connection as ReverbConnection;
+use Laravel\Reverb\Servers\Reverb\Http\Connection;
+use Laravel\Reverb\Servers\Reverb\Http\Route;
+use Laravel\Reverb\Servers\Reverb\Http\Router;
+use Laravel\Reverb\Tests\FakeRawSocketConnection;
+use Psr\Http\Message\RequestInterface;
+use Symfony\Component\Routing\Matcher\UrlMatcher;
+use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Stand-in for a WebSocket-only controller (e.g. PusherController), which
+ * type-hints the upgraded `Servers\Reverb\Connection`.
+ */
+class FakeWebSocketOnlyController
+{
+    public bool $invoked = false;
+
+    public function __invoke(RequestInterface $request, ReverbConnection $connection, string $appKey): void
+    {
+        $this->invoked = true;
+    }
+}
+
+/**
+ * Stand-in for a plain HTTP controller, which type-hints the raw HTTP
+ * connection and returns a response.
+ */
+class FakeHttpController
+{
+    public function __invoke(RequestInterface $request, Connection $connection, string $appId): string
+    {
+        return 'ok';
+    }
+}
+
+function makeRouter(callable $controller, string $path = '/app/{appKey}'): Router
+{
+    $routes = new RouteCollection;
+    $routes->add('test', Route::get($path, $controller));
+
+    return new Router(new UrlMatcher($routes, new RequestContext));
+}
+
+it('does not treat a missing Upgrade header as a WebSocket request', function () {
+    $router = makeRouter(new FakeWebSocketOnlyController);
+    $isWebSocketRequest = new ReflectionMethod($router, 'isWebSocketRequest');
+
+    $request = new Request('GET', '/app/reverb-key');
+
+    expect($isWebSocketRequest->invoke($router, $request))->toBeFalse();
+});
+
+it('does not treat an unrelated Upgrade header value as a WebSocket request', function () {
+    $router = makeRouter(new FakeWebSocketOnlyController);
+    $isWebSocketRequest = new ReflectionMethod($router, 'isWebSocketRequest');
+
+    // Previously, due to an operator-precedence bug, any non-null Upgrade
+    // header value (not just "websocket") was treated as truthy here.
+    $request = new Request('GET', '/app/reverb-key', ['Upgrade' => 'h2c']);
+
+    expect($isWebSocketRequest->invoke($router, $request))->toBeFalse();
+});
+
+it('treats a genuine websocket Upgrade header as a WebSocket request', function () {
+    $router = makeRouter(new FakeWebSocketOnlyController);
+    $isWebSocketRequest = new ReflectionMethod($router, 'isWebSocketRequest');
+
+    $request = new Request('GET', '/app/reverb-key', ['Upgrade' => 'websocket']);
+
+    expect($isWebSocketRequest->invoke($router, $request))->toBeTrue();
+});
+
+it('returns a 426 response instead of crashing when a plain HTTP request hits a WebSocket-only controller', function () {
+    $controller = new FakeWebSocketOnlyController;
+    $router = makeRouter($controller);
+
+    $rawConnection = new FakeRawSocketConnection;
+    $connection = new Connection($rawConnection);
+
+    // A plain, non-upgrade request (e.g. a health check, curl -I, or a
+    // proxy that stripped the Upgrade header) hitting the WebSocket route.
+    $request = new Request('GET', '/app/reverb-key');
+
+    $router->dispatch($request, $connection);
+
+    expect($controller->invoked)->toBeFalse();
+    expect($rawConnection->ended)->toBeTrue();
+    expect($rawConnection->written)->not->toBeEmpty();
+    expect($rawConnection->written[0])->toContain('426');
+    expect($rawConnection->written[0])->toContain('Upgrade: websocket');
+});
+
+it('still dispatches plain HTTP requests to plain HTTP controllers', function () {
+    $router = makeRouter(new FakeHttpController, '/apps/{appId}');
+
+    $rawConnection = new FakeRawSocketConnection;
+    $connection = new Connection($rawConnection);
+
+    $request = new Request('GET', '/apps/1234');
+
+    $router->dispatch($request, $connection);
+
+    expect($rawConnection->ended)->toBeTrue();
+    expect($rawConnection->written)->not->toBeEmpty();
+    expect($rawConnection->written[0])->toContain('ok');
+});


### PR DESCRIPTION
## Summary

Fixes #344 — `TypeError` in `PusherController::__invoke()` when a plain (non-upgrade) HTTP request hits the WebSocket route.

There are two distinct problems here, and fixing only the first does **not** fix the bug as reported:

1. **Operator-precedence bug** in `Router::isWebSocketRequest()`:

   ```php
   return $request->getHeader('Upgrade')[0] ?? null === 'websocket';
   ```

   Because `===` binds tighter than `??` in PHP, this parses as `... ?? (null === 'websocket')`, i.e. `... ?? false`. Any *present* Upgrade header value (not just `"websocket"`) is short-circuited by `??` and returned as-is (truthy), while a *missing* header still correctly falls through to `false`. Fixed by parenthesizing as intended:

   ```php
   return ($request->getHeader('Upgrade')[0] ?? null) === 'websocket';
   ```

2. **The actual crash reported in #344 is caused by something else.** When the `Upgrade` header is missing entirely (a proxy stripped it, `curl -I`, a health check, etc.), `isWebSocketRequest()` already correctly returns `false` even with the precedence bug present. `Router::dispatch()` then falls through to the non-WebSocket branch and still invokes `PusherController` with the raw `Http\Connection` — but `PusherController::__invoke()` type-hints the upgraded `Servers\Reverb\Connection`, so PHP throws a `TypeError` on the object-type mismatch. Fixing only the precedence bug does not touch this path at all, since a missing header already evaluated to `false` before the fix too.

   To fix the actual crash, `Router::requiresWebSocketUpgrade()` inspects the matched controller's reflected parameter types. If the controller requires the upgraded `Servers\Reverb\Connection` (currently only `PusherController`) and the request isn't a genuine WebSocket upgrade, the router now responds `426 Upgrade Required` instead of invoking the controller with the wrong connection type.

## Relation to #377

#377 proposed the identical precedence fix (plus the same `426` guard idea) but was auto-closed by the stale-bot for being left in draft, not because it was rejected on its merits — see the bot's own comment on that PR. This PR resubmits the same underlying fix, ready for review.

## Test plan

- [x] Added `tests/Unit/Servers/Reverb/Http/RouterTest.php`:
  - `isWebSocketRequest()` returns `false` for a missing `Upgrade` header, `false` for an unrelated `Upgrade` value (e.g. `h2c` — this is the precedence-bug regression case), and `true` for a genuine `websocket` value.
  - A plain HTTP request dispatched to a WebSocket-only controller returns a `426` response with an `Upgrade: websocket` header and does **not** invoke the controller (previously this hit the reported `TypeError`).
  - A plain HTTP request to an ordinary HTTP controller still dispatches normally (no regression to existing routes: events, channels, health check, etc.).
- [ ] **Not executed** — this environment does not have a PHP runtime available, so the test was written against the repo's actual Pest/PHPUnit conventions (using `GuzzleHttp\Psr7\Request`, a hand-rolled `React\Socket\ConnectionInterface` fake matching the pinned `react/socket: ^1.14` / `react/stream` interfaces, and reflection to reach the protected router methods) but could not be run locally to confirm green. Please run `./vendor/bin/pest --filter=RouterTest` (or let CI run it) before merging.

Closes #344
