### PR TITLE
Return channels as an object when none are occupied

### DIFF
--- a/src/Protocols/Pusher/Http/Controllers/ChannelsController.php
+++ b/src/Protocols/Pusher/Http/Controllers/ChannelsController.php
@@ -20,6 +20,6 @@ class ChannelsController extends Controller
         return app(MetricsHandler::class)->gather($this->application, 'channels', [
             'filter' => $this->query['filter_by_prefix'] ?? null,
             'info' => $this->query['info'] ?? null,
-        ])->then(fn ($channels) => new Response(['channels' => array_map(fn ($item) => (object) $item, $channels)]));
+        ])->then(fn ($channels) => new Response(['channels' => (object) array_map(fn ($item) => (object) $item, $channels)]));
     }
 }

--- a/tests/Feature/Protocols/Pusher/Reverb/ChannelsControllerTest.php
+++ b/tests/Feature/Protocols/Pusher/Reverb/ChannelsControllerTest.php
@@ -61,6 +61,13 @@ it('can send the content-length header', function () {
     expect($response->getHeader('Content-Length'))->toBe(['81']);
 });
 
+it('returns an object when no channels are occupied', function () {
+    $response = await($this->signedRequest('channels'));
+
+    expect($response->getStatusCode())->toBe(200);
+    expect($response->getBody()->getContents())->toBe('{"channels":{}}');
+});
+
 it('can gather all channel information', function () {
     $this->usingRedis();
 

--- a/tests/Feature/Protocols/Pusher/Reverb/ChannelsControllerTest.php
+++ b/tests/Feature/Protocols/Pusher/Reverb/ChannelsControllerTest.php
@@ -131,6 +131,15 @@ it('can send the content-length header when gathering results', function () {
     expect($response->getHeader('Content-Length'))->toBe(['81']);
 });
 
+it('gathers an object when no channels are occupied', function () {
+    $this->usingRedis();
+
+    $response = await($this->signedRequest('channels'));
+
+    expect($response->getStatusCode())->toBe(200);
+    expect($response->getBody()->getContents())->toBe('{"channels":{}}');
+});
+
 it('fails when using an invalid signature', function () {
     $response = await($this->request('channels?info=user_count'));
 


### PR DESCRIPTION
`GET /apps/{appId}/channels` returns `{"channels":[]}` instead of `{"channels":{}}` when no channels are occupied, because `array_map` only casts the individual channel entries to objects and leaves the outer container a plain array, which `json_encode` renders as a list once it's empty. That breaks `pusher/pusher-php-server`'s `getChannels()`, which calls `get_object_vars()` on the channels value and expects an object, so it throws a `TypeError` exactly when no channel is occupied.

Casting the container itself to an object keeps the response shape consistent regardless of how many channels are occupied.

Fixes #402
