### PR TITLE
Fix TypeError in PusherController when a non-upgrade request hits the WebSocket route (#344)

### DIFF
--- a/src/Servers/Reverb/Http/Router.php
+++ b/src/Servers/Reverb/Http/Router.php
@@ -66,6 +66,12 @@ class Router
             return $controller($request, $wsConnection, ...Arr::except($route, ['_controller', '_route']));
         }
 
+        if ($this->requiresWebSocketUpgrade($controller)) {
+            $this->close($connection, 426, 'Upgrade required.', ['Upgrade' => 'websocket']);
+
+            return null;
+        }
+
         $routeParameters = Arr::except($route, [
             '_controller',
             '_route',
@@ -95,7 +101,21 @@ class Router
      */
     protected function isWebSocketRequest(RequestInterface $request): bool
     {
-        return $request->getHeader('Upgrade')[0] ?? null === 'websocket';
+        return ($request->getHeader('Upgrade')[0] ?? null) === 'websocket';
+    }
+
+    /**
+     * Determine whether the controller requires an upgraded WebSocket connection.
+     */
+    protected function requiresWebSocketUpgrade(callable $controller): bool
+    {
+        foreach ($this->parameters($controller) as $parameter) {
+            if ($parameter['type'] === ReverbConnection::class) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/tests/FakeRawSocketConnection.php
+++ b/tests/FakeRawSocketConnection.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Laravel\Reverb\Tests;
+
+use React\Socket\ConnectionInterface;
+use React\Stream\WritableStreamInterface;
+
+/**
+ * A minimal fake of a raw ReactPHP socket connection, used to build a real
+ * `Laravel\Reverb\Servers\Reverb\Http\Connection` in tests without a socket.
+ */
+class FakeRawSocketConnection implements ConnectionInterface
+{
+    public $stream = 1;
+
+    /**
+     * Data written to the connection.
+     *
+     * @var array<int, string>
+     */
+    public array $written = [];
+
+    public bool $ended = false;
+
+    public function write($data)
+    {
+        $this->written[] = $data;
+
+        return true;
+    }
+
+    public function end($data = null)
+    {
+        $this->ended = true;
+    }
+
+    public function close()
+    {
+        //
+    }
+
+    public function pause()
+    {
+        //
+    }
+
+    public function resume()
+    {
+        //
+    }
+
+    public function pipe(WritableStreamInterface $dest, array $options = [])
+    {
+        return $dest;
+    }
+
+    public function isReadable()
+    {
+        return true;
+    }
+
+    public function isWritable()
+    {
+        return true;
+    }
+
+    public function getRemoteAddress()
+    {
+        return null;
+    }
+
+    public function getLocalAddress()
+    {
+        return null;
+    }
+
+    public function on($event, callable $listener)
+    {
+        //
+    }
+
+    public function once($event, callable $listener)
+    {
+        //
+    }
+
+    public function removeListener($event, callable $listener)
+    {
+        //
+    }
+
+    public function removeAllListeners($event = null)
+    {
+        //
+    }
+
+    public function listeners($event = null)
+    {
+        return [];
+    }
+
+    public function emit($event, array $arguments = [])
+    {
+        //
+    }
+}

--- a/tests/Unit/Servers/Reverb/Http/RouterTest.php
+++ b/tests/Unit/Servers/Reverb/Http/RouterTest.php
@@ -1,0 +1,110 @@
+<?php
+
+use GuzzleHttp\Psr7\Request;
+use Laravel\Reverb\Servers\Reverb\Connection as ReverbConnection;
+use Laravel\Reverb\Servers\Reverb\Http\Connection;
+use Laravel\Reverb\Servers\Reverb\Http\Route;
+use Laravel\Reverb\Servers\Reverb\Http\Router;
+use Laravel\Reverb\Tests\FakeRawSocketConnection;
+use Psr\Http\Message\RequestInterface;
+use Symfony\Component\Routing\Matcher\UrlMatcher;
+use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Stand-in for a WebSocket-only controller (e.g. PusherController), which
+ * type-hints the upgraded `Servers\Reverb\Connection`.
+ */
+class FakeWebSocketOnlyController
+{
+    public bool $invoked = false;
+
+    public function __invoke(RequestInterface $request, ReverbConnection $connection, string $appKey): void
+    {
+        $this->invoked = true;
+    }
+}
+
+/**
+ * Stand-in for a plain HTTP controller, which type-hints the raw HTTP
+ * connection and returns a response.
+ */
+class FakeHttpController
+{
+    public function __invoke(RequestInterface $request, Connection $connection, string $appId): string
+    {
+        return 'ok';
+    }
+}
+
+function makeRouter(callable $controller, string $path = '/app/{appKey}'): Router
+{
+    $routes = new RouteCollection;
+    $routes->add('test', Route::get($path, $controller));
+
+    return new Router(new UrlMatcher($routes, new RequestContext));
+}
+
+it('does not treat a missing Upgrade header as a WebSocket request', function () {
+    $router = makeRouter(new FakeWebSocketOnlyController);
+    $isWebSocketRequest = new ReflectionMethod($router, 'isWebSocketRequest');
+
+    $request = new Request('GET', '/app/reverb-key');
+
+    expect($isWebSocketRequest->invoke($router, $request))->toBeFalse();
+});
+
+it('does not treat an unrelated Upgrade header value as a WebSocket request', function () {
+    $router = makeRouter(new FakeWebSocketOnlyController);
+    $isWebSocketRequest = new ReflectionMethod($router, 'isWebSocketRequest');
+
+    // Previously, due to an operator-precedence bug, any non-null Upgrade
+    // header value (not just "websocket") was treated as truthy here.
+    $request = new Request('GET', '/app/reverb-key', ['Upgrade' => 'h2c']);
+
+    expect($isWebSocketRequest->invoke($router, $request))->toBeFalse();
+});
+
+it('treats a genuine websocket Upgrade header as a WebSocket request', function () {
+    $router = makeRouter(new FakeWebSocketOnlyController);
+    $isWebSocketRequest = new ReflectionMethod($router, 'isWebSocketRequest');
+
+    $request = new Request('GET', '/app/reverb-key', ['Upgrade' => 'websocket']);
+
+    expect($isWebSocketRequest->invoke($router, $request))->toBeTrue();
+});
+
+it('returns a 426 response instead of crashing when a plain HTTP request hits a WebSocket-only controller', function () {
+    $controller = new FakeWebSocketOnlyController;
+    $router = makeRouter($controller);
+
+    $rawConnection = new FakeRawSocketConnection;
+    $connection = new Connection($rawConnection);
+
+    // A plain, non-upgrade request (e.g. a health check, curl -I, or a
+    // proxy that stripped the Upgrade header) hitting the WebSocket route.
+    $request = new Request('GET', '/app/reverb-key');
+
+    $router->dispatch($request, $connection);
+
+    expect($controller->invoked)->toBeFalse();
+    expect($rawConnection->ended)->toBeTrue();
+    expect($rawConnection->written)->not->toBeEmpty();
+    expect($rawConnection->written[0])->toContain('426');
+    expect($rawConnection->written[0])->toContain('Upgrade: websocket');
+});
+
+it('still dispatches plain HTTP requests to plain HTTP controllers', function () {
+    $router = makeRouter(new FakeHttpController, '/apps/{appId}');
+
+    $rawConnection = new FakeRawSocketConnection;
+    $connection = new Connection($rawConnection);
+
+    $request = new Request('GET', '/apps/1234');
+
+    $router->dispatch($request, $connection);
+
+    expect($rawConnection->ended)->toBeTrue();
+    expect($rawConnection->written)->not->toBeEmpty();
+    expect($rawConnection->written[0])->toContain('ok');
+});


### PR DESCRIPTION
Fixes #344.

I dug into the TypeError people are hitting in `PusherController::__invoke()` and it comes down to two separate bugs in `Router` that compound each other.

The first is a small operator-precedence mistake in `isWebSocketRequest()`:

```php
return $request->getHeader('Upgrade')[0] ?? null === 'websocket';
```

Since `===` binds tighter than `??`, this actually evaluates as `... ?? (null === 'websocket')`, which is just `... ?? false`. So any request that does carry an `Upgrade` header, whatever its value, short-circuits through the `??` and gets returned as-is (truthy), instead of being checked against `'websocket'`. A request with `Upgrade: h2c`, for instance, would be wrongly treated as a WebSocket request.

But that's not actually what's causing the reported crash. When the `Upgrade` header is missing entirely, which is the common case people are hitting (a proxy stripping it, `curl -I`, a load balancer health check), `isWebSocketRequest()` already returns `false` correctly even with the precedence bug in place. So `dispatch()` falls into the non-WebSocket branch and calls the matched controller with the plain `Http\Connection`. The problem is that `PusherController::__invoke()` type-hints the upgraded `Servers\Reverb\Connection`, not `Http\Connection`, so PHP throws the TypeError as soon as it tries to bind that argument. Fixing only the precedence bug wouldn't touch this at all, since a missing header already evaluated to `false` before the fix too.

So the real fix needs a guard in `dispatch()`: before invoking the controller on the non-upgrade path, check whether that controller actually requires the upgraded connection type. I added `requiresWebSocketUpgrade()`, which reflects on the controller's parameters and checks for `Servers\Reverb\Connection`. If it needs it and the request never upgraded, the router now responds with `426 Upgrade Required` and an `Upgrade: websocket` header instead of calling the controller with the wrong object and crashing.

I also fixed the precedence bug itself since it's a real (if separate) issue in the same method, and it's worth having a regression test for it either way.

Someone else, nathanpixodeo, diagnosed this exact same root cause in a comment on the issue, and there was an earlier draft PR (#377) that got closed by the stale bot before it was finished, not because it was rejected — so this has been correctly identified before, it just hasn't landed.

For testing, I added `tests/Unit/Servers/Reverb/Http/RouterTest.php` and a small fake raw socket connection to build a real `Http\Connection` in tests without an actual socket. It covers: `isWebSocketRequest()` returning false for a missing header, false for an unrelated header value like `h2c` (the precedence regression case), and true for a genuine `websocket` value; a plain HTTP request to a WebSocket-only controller now getting a 426 instead of crashing; and a sanity check that ordinary HTTP routes still dispatch normally so nothing regresses there.

I ran the full suite locally in a PHP 8.4 container (this environment doesn't have PHP installed natively) — `vendor/bin/pest --testsuite=Unit` passes all 121 tests, and the new `RouterTest` passes 5/5. I also confirmed the new tests actually fail against unpatched `Router.php` (2 of the 5 fail), so they're exercising the real bug and not just passing trivially.
