### PR TITLE
Close the connection when the WebSocket handshake fails

### DIFF
--- a/src/Servers/Reverb/Http/Router.php
+++ b/src/Servers/Reverb/Http/Router.php
@@ -61,7 +61,9 @@ class Router
         $controller = $this->controller($route);
 
         if ($this->isWebSocketRequest($request)) {
-            $wsConnection = $this->attemptUpgrade($request, $connection);
+            if (! $wsConnection = $this->attemptUpgrade($request, $connection)) {
+                return null;
+            }
 
             return $controller($request, $wsConnection, ...Arr::except($route, ['_controller', '_route']));
         }
@@ -101,12 +103,18 @@ class Router
     /**
      * Negotiate the WebSocket connection upgrade.
      */
-    protected function attemptUpgrade(RequestInterface $request, Connection $connection): ReverbConnection
+    protected function attemptUpgrade(RequestInterface $request, Connection $connection): ?ReverbConnection
     {
         $response = $this->negotiator->handshake($request)
             ->withHeader('X-Powered-By', 'Laravel Reverb');
 
         $connection->write(Message::toString($response));
+
+        if ($response->getStatusCode() !== 101) {
+            $connection->close();
+
+            return null;
+        }
 
         return new ReverbConnection($connection);
     }

--- a/tests/Feature/Protocols/Pusher/Reverb/ServerTest.php
+++ b/tests/Feature/Protocols/Pusher/Reverb/ServerTest.php
@@ -5,6 +5,7 @@ use Laravel\Reverb\Jobs\PingInactiveConnections;
 use Laravel\Reverb\Jobs\PruneStaleConnections;
 use Laravel\Reverb\Tests\ReverbTestCase;
 use Ratchet\RFC6455\Messaging\Frame;
+use React\Http\Browser;
 use React\Http\Message\ResponseException;
 use React\Promise\Deferred;
 
@@ -582,3 +583,25 @@ it('sets the x-powered-by header', function () {
 
     expect($connection->connection->response->getHeader('X-Powered-By')[0])->toBe('Laravel Reverb');
 });
+
+it('rejects a handshake with an invalid websocket key', function () {
+    await(
+        (new Browser($this->loop))->withTimeout(5)->request('GET', 'http://0.0.0.0:8080/app/reverb-key', [
+            'Connection' => 'Upgrade',
+            'Upgrade' => 'websocket',
+            'Sec-WebSocket-Key' => 'invalid-key',
+            'Sec-WebSocket-Version' => '13',
+        ])
+    );
+})->throws(ResponseException::class, exceptionCode: 400);
+
+it('rejects a handshake requesting an unsupported websocket version', function () {
+    await(
+        (new Browser($this->loop))->withTimeout(5)->request('GET', 'http://0.0.0.0:8080/app/reverb-key', [
+            'Connection' => 'Upgrade',
+            'Upgrade' => 'websocket',
+            'Sec-WebSocket-Key' => 'dGhlIHNhbXBsZSBub25jZQ==',
+            'Sec-WebSocket-Version' => '8',
+        ])
+    );
+})->throws(ResponseException::class, exceptionCode: 426);


### PR DESCRIPTION
When `ServerNegotiator` rejects a handshake it returns the appropriate response — 400 for an invalid `Sec-WebSocket-Key`, 426 for an unsupported `Sec-WebSocket-Version` — but `attemptUpgrade()` writes that response and returns a `ReverbConnection` regardless of its status. The connection is never closed, and `dispatch()` then invokes the controller with a connection that was never upgraded.

A client sending a malformed handshake therefore receives a response that never terminates. A strict HTTP client waits until it times out; `curl` reports the status and exits, leaving the connection held open on the server. Repeated by a scanner, these accumulate.

This closes the connection and returns `null` when the negotiator's status is not 101, so `dispatch()` stops before reaching the controller.

The two added tests cover the invalid key and unsupported version paths. Both fail against `main`.
